### PR TITLE
Fix arguments in "topcfg setpos"

### DIFF
--- a/src/main/java/mcjty/theoneprobe/commands/CommandTopCfg.java
+++ b/src/main/java/mcjty/theoneprobe/commands/CommandTopCfg.java
@@ -56,7 +56,7 @@ public class CommandTopCfg implements ICommand {
 
 
     private static void setPos(String[] args) {
-        if (args.length != 4) {
+        if (args.length != 5) {
             return;
         }
         try {


### PR DESCRIPTION
"topcfg setpos" needs 5 arguments to work without exception and not 4
Fix for Issue #33 
