### PR TITLE
1.10 less hardcoded api

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProbeCheck.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeCheck.java
@@ -1,0 +1,7 @@
+package mcjty.theoneprobe.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+public interface IProbeCheck {
+	boolean hasProbe(EntityPlayer player);
+}

--- a/src/main/java/mcjty/theoneprobe/api/IProbeItem.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeItem.java
@@ -1,0 +1,8 @@
+package mcjty.theoneprobe.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public interface IProbeItem {
+	boolean canWorkAsProbe(ItemStack stack, EntityPlayer player);
+}

--- a/src/main/java/mcjty/theoneprobe/api/ProbeChecker.java
+++ b/src/main/java/mcjty/theoneprobe/api/ProbeChecker.java
@@ -2,15 +2,27 @@ package mcjty.theoneprobe.api;
 
 import baubles.api.BaublesApi;
 import baubles.api.cap.IBaublesItemHandler;
+import com.google.common.collect.Sets;
 import mcjty.theoneprobe.TheOneProbe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
 
+import java.util.Set;
+
 public class ProbeChecker {
 
 	public static String PROBETAG = "theoneprobe";
 	public static String PROBETAG_HAND = "theoneprobe_hand";
+	private static final Set<IProbeCheck> CHECKS = Sets.newHashSet();
+
+	//Default checks
+	static {
+		addCheck(p -> hasProbeInHand(p, EnumHand.MAIN_HAND));
+		addCheck(p -> hasProbeInHand(p, EnumHand.OFF_HAND));
+		addCheck(ProbeChecker::hasProbeInHelmet);
+		addCheck(ProbeChecker::hasProbeInBauble);
+	}
 
 	public static boolean canWorkAsProbe(ItemStack stack, EntityPlayer player, String nbtProbeTagName) {
 		if (stack == null) {
@@ -23,8 +35,7 @@ public class ProbeChecker {
 	}
 
 	public static boolean hasAProbeSomewhere(EntityPlayer player) {
-		return hasProbeInHand(player, EnumHand.MAIN_HAND) || hasProbeInHand(player, EnumHand.OFF_HAND) || hasProbeInHelmet(player)
-			|| hasProbeInBauble(player);
+		return CHECKS.parallelStream().anyMatch(c -> c.hasProbe(player));
 	}
 
 	public static boolean hasProbeInHand(EntityPlayer player, EnumHand hand) {
@@ -46,6 +57,10 @@ public class ProbeChecker {
 			}
 		}
 		return false;
+	}
+
+	public static void addCheck(IProbeCheck check) {
+		CHECKS.add(check);
 	}
 
 }

--- a/src/main/java/mcjty/theoneprobe/api/ProbeChecker.java
+++ b/src/main/java/mcjty/theoneprobe/api/ProbeChecker.java
@@ -1,0 +1,51 @@
+package mcjty.theoneprobe.api;
+
+import baubles.api.BaublesApi;
+import baubles.api.cap.IBaublesItemHandler;
+import mcjty.theoneprobe.TheOneProbe;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+public class ProbeChecker {
+
+	public static String PROBETAG = "theoneprobe";
+	public static String PROBETAG_HAND = "theoneprobe_hand";
+
+	public static boolean canWorkAsProbe(ItemStack stack, EntityPlayer player, String nbtProbeTagName) {
+		if (stack == null) {
+			return false;
+		}
+		if (stack.getItem() instanceof IProbeItem) {
+			return ((IProbeItem) stack.getItem()).canWorkAsProbe(stack, player);
+		}
+		return stack.getTagCompound() != null && stack.getTagCompound().hasKey(nbtProbeTagName);
+	}
+
+	public static boolean hasAProbeSomewhere(EntityPlayer player) {
+		return hasProbeInHand(player, EnumHand.MAIN_HAND) || hasProbeInHand(player, EnumHand.OFF_HAND) || hasProbeInHelmet(player)
+			|| hasProbeInBauble(player);
+	}
+
+	public static boolean hasProbeInHand(EntityPlayer player, EnumHand hand) {
+		return canWorkAsProbe(player.getHeldItem(hand), player, PROBETAG_HAND);
+	}
+
+	public static boolean hasProbeInHelmet(EntityPlayer player) {
+		return canWorkAsProbe(player.inventory.armorInventory[3], player, PROBETAG);
+	}
+
+	public static boolean hasProbeInBauble(EntityPlayer player) {
+		if (TheOneProbe.baubles) {
+			IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(player);
+			int slots = baubles.getSlots();
+			for(int i = 0; i < slots; i++) {
+				if(canWorkAsProbe(baubles.getStackInSlot(i), player, PROBETAG)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/HarvestInfoTools.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/HarvestInfoTools.java
@@ -10,6 +10,7 @@ import mcjty.theoneprobe.items.ModItems;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -45,7 +46,7 @@ public class HarvestInfoTools {
     }
 
     static void showCanBeHarvested(IProbeInfo probeInfo, World world, BlockPos pos, Block block, EntityPlayer player) {
-        if (ModItems.isProbeInHand(player.getHeldItemMainhand())) {
+        if (ModItems.hasProbeInHand(player, EnumHand.MAIN_HAND)) {
             // If the player holds the probe there is no need to show harvestability information as the
             // probe cannot harvest anything. This is only supposed to work in off hand.
             return;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/HarvestInfoTools.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/HarvestInfoTools.java
@@ -1,10 +1,7 @@
 package mcjty.theoneprobe.apiimpl.providers;
 
 import mcjty.theoneprobe.TheOneProbe;
-import mcjty.theoneprobe.api.ElementAlignment;
-import mcjty.theoneprobe.api.IIconStyle;
-import mcjty.theoneprobe.api.ILayoutStyle;
-import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.*;
 import mcjty.theoneprobe.config.Config;
 import mcjty.theoneprobe.items.ModItems;
 import net.minecraft.block.Block;
@@ -46,7 +43,7 @@ public class HarvestInfoTools {
     }
 
     static void showCanBeHarvested(IProbeInfo probeInfo, World world, BlockPos pos, Block block, EntityPlayer player) {
-        if (ModItems.hasProbeInHand(player, EnumHand.MAIN_HAND)) {
+        if (ProbeChecker.hasProbeInHand(player, EnumHand.MAIN_HAND)) {
             // If the player holds the probe there is no need to show harvestability information as the
             // probe cannot harvest anything. This is only supposed to work in off hand.
             return;

--- a/src/main/java/mcjty/theoneprobe/compat/ProbeGoggles.java
+++ b/src/main/java/mcjty/theoneprobe/compat/ProbeGoggles.java
@@ -1,10 +1,13 @@
 package mcjty.theoneprobe.compat;
 
 import baubles.api.BaubleType;
+import baubles.api.BaublesApi;
 import baubles.api.IBauble;
 import mcjty.theoneprobe.TheOneProbe;
+import mcjty.theoneprobe.api.IProbeItem;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
@@ -12,7 +15,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ProbeGoggles extends Item implements IBauble {
+public class ProbeGoggles extends Item implements IBauble, IProbeItem {
 
     public ProbeGoggles() {
         setUnlocalizedName(TheOneProbe.MODID + ".probe_goggles");
@@ -59,5 +62,10 @@ public class ProbeGoggles extends Item implements IBauble {
     @Override
     public boolean willAutoSync(ItemStack itemstack, EntityLivingBase player) {
         return false;
+    }
+
+    @Override
+    public boolean canWorkAsProbe(ItemStack stack, EntityPlayer player) {
+        return BaublesApi.getBaublesHandler(player).getStackInSlot(4) == stack;
     }
 }

--- a/src/main/java/mcjty/theoneprobe/items/AddProbeRecipe.java
+++ b/src/main/java/mcjty/theoneprobe/items/AddProbeRecipe.java
@@ -1,5 +1,7 @@
 package mcjty.theoneprobe.items;
 
+import mcjty.theoneprobe.api.IProbeItem;
+import mcjty.theoneprobe.api.ProbeChecker;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -18,9 +20,11 @@ public class AddProbeRecipe extends ShapedRecipes {
     @Override
     public ItemStack getCraftingResult(InventoryCrafting inv) {
         ItemStack result = super.getCraftingResult(inv);
-        NBTTagCompound tc = new NBTTagCompound();
-        tc.setInteger(ModItems.PROBETAG, 1);
-        result.setTagCompound(tc);
+        if(result != null && !(result.getItem() instanceof IProbeItem)) { //Only set probetag if result item is not IProbeItem
+            NBTTagCompound tc = new NBTTagCompound();
+            tc.setInteger(ProbeChecker.PROBETAG, 1);
+            result.setTagCompound(tc);
+        }
         return result;
     }
 }

--- a/src/main/java/mcjty/theoneprobe/items/CreativeProbe.java
+++ b/src/main/java/mcjty/theoneprobe/items/CreativeProbe.java
@@ -1,14 +1,17 @@
 package mcjty.theoneprobe.items;
 
 import mcjty.theoneprobe.TheOneProbe;
+import mcjty.theoneprobe.api.IProbeItem;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class CreativeProbe extends Item {
+public class CreativeProbe extends Item implements IProbeItem{
 
     public CreativeProbe() {
         setUnlocalizedName(TheOneProbe.MODID + ".creativeprobe");
@@ -23,4 +26,8 @@ public class CreativeProbe extends Item {
     }
 
 
+    @Override
+    public boolean canWorkAsProbe(ItemStack stack, EntityPlayer player) {
+        return true;
+    }
 }

--- a/src/main/java/mcjty/theoneprobe/items/ItemProbedArmor.java
+++ b/src/main/java/mcjty/theoneprobe/items/ItemProbedArmor.java
@@ -1,0 +1,12 @@
+package mcjty.theoneprobe.items;
+
+import mcjty.theoneprobe.api.IProbeItem;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemArmor;
+
+public abstract class ItemProbedArmor extends ItemArmor implements IProbeItem {
+
+	public ItemProbedArmor(ArmorMaterial materialIn, int renderIndexIn, EntityEquipmentSlot equipmentSlotIn) {
+		super(materialIn, renderIndexIn, equipmentSlotIn);
+	}
+}

--- a/src/main/java/mcjty/theoneprobe/items/ModItems.java
+++ b/src/main/java/mcjty/theoneprobe/items/ModItems.java
@@ -1,9 +1,7 @@
 package mcjty.theoneprobe.items;
 
-import baubles.api.BaublesApi;
-import baubles.api.cap.IBaublesItemHandler;
 import mcjty.theoneprobe.TheOneProbe;
-import mcjty.theoneprobe.api.IProbeItem;
+import mcjty.theoneprobe.api.ProbeChecker;
 import mcjty.theoneprobe.compat.BaubleTools;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
@@ -14,7 +12,6 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumHand;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.util.EnumHelper;
@@ -34,9 +31,6 @@ public class ModItems {
     public static Item ironHelmetProbe;
     public static Item probeGoggles;
     public static ProbeNote probeNote;
-
-    public static String PROBETAG = "theoneprobe";
-    public static String PROBETAG_HAND = "theoneprobe_hand";
 
     static {
         RecipeSorter.register("theoneprobe:addproberecipe", AddProbeRecipe.class, RecipeSorter.Category.SHAPED, "after:minecraft:shaped");
@@ -122,39 +116,45 @@ public class ModItems {
         }
     }
 
+
+
+    /**
+     * @deprecated See {@link ProbeChecker}
+     */
+    @Deprecated
     public static boolean canWorkAsProbe(ItemStack stack, EntityPlayer player, String nbtProbeTagName) {
-        if (stack == null) {
-            return false;
-        }
-        if (stack.getItem() instanceof IProbeItem) {
-            return ((IProbeItem) stack.getItem()).canWorkAsProbe(stack, player);
-        }
-        return stack.getTagCompound() != null && stack.getTagCompound().hasKey(nbtProbeTagName);
+        return ProbeChecker.canWorkAsProbe(stack ,player, nbtProbeTagName);
     }
 
+    /**
+     * @deprecated See {@link ProbeChecker}
+     */
+    @Deprecated
     public static boolean hasAProbeSomewhere(EntityPlayer player) {
-        return hasProbeInHand(player, EnumHand.MAIN_HAND) || hasProbeInHand(player, EnumHand.OFF_HAND) || hasProbeInHelmet(player)
-                || hasProbeInBauble(player);
+        return ProbeChecker.hasAProbeSomewhere(player);
     }
 
+    /**
+     * @deprecated See {@link ProbeChecker}
+     */
+    @Deprecated
     public static boolean hasProbeInHand(EntityPlayer player, EnumHand hand) {
-        return canWorkAsProbe(player.getHeldItem(hand), player, PROBETAG_HAND);
+        return ProbeChecker.hasProbeInHand(player, hand);
     }
 
+    /**
+     * @deprecated See {@link ProbeChecker}
+     */
+    @Deprecated
     public static boolean hasProbeInHelmet(EntityPlayer player) {
-        return canWorkAsProbe(player.inventory.armorInventory[3], player, PROBETAG);
+        return ProbeChecker.hasProbeInHelmet(player);
     }
 
+    /**
+     * @deprecated See {@link ProbeChecker}
+     */
+    @Deprecated
     public static boolean hasProbeInBauble(EntityPlayer player) {
-        if (TheOneProbe.baubles) {
-            IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(player);
-            int slots = baubles.getSlots();
-            for(int i = 0; i < slots; i++) {
-                if(canWorkAsProbe(baubles.getStackInSlot(i), player, PROBETAG)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return ProbeChecker.hasProbeInBauble(player);
     }
 }

--- a/src/main/java/mcjty/theoneprobe/items/ModItems.java
+++ b/src/main/java/mcjty/theoneprobe/items/ModItems.java
@@ -79,9 +79,10 @@ public class ModItems {
             @Override
             public void getSubItems(Item itemIn, CreativeTabs tab, List<ItemStack> subItems) {
                 ItemStack stack = new ItemStack(itemIn);
-                NBTTagCompound tag = new NBTTagCompound();
+                //No need for tag, because IProbeItem is implemented
+                /*NBTTagCompound tag = new NBTTagCompound();
                 tag.setInteger(PROBETAG, 1);
-                stack.setTagCompound(tag);
+                stack.setTagCompound(tag);*/
                 subItems.add(stack);
             }
         };

--- a/src/main/java/mcjty/theoneprobe/items/Probe.java
+++ b/src/main/java/mcjty/theoneprobe/items/Probe.java
@@ -1,6 +1,7 @@
 package mcjty.theoneprobe.items;
 
 import mcjty.theoneprobe.TheOneProbe;
+import mcjty.theoneprobe.api.IProbeItem;
 import mcjty.theoneprobe.proxy.GuiProxy;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.player.EntityPlayer;
@@ -15,7 +16,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class Probe extends Item {
+public class Probe extends Item implements IProbeItem{
 
     public Probe() {
         setUnlocalizedName(TheOneProbe.MODID + ".probe");
@@ -39,4 +40,8 @@ public class Probe extends Item {
         return new ActionResult<>(EnumActionResult.SUCCESS, stack);
     }
 
+    @Override
+    public boolean canWorkAsProbe(ItemStack stack, EntityPlayer player) {
+        return true;
+    }
 }

--- a/src/main/java/mcjty/theoneprobe/network/PacketGetEntityInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketGetEntityInfo.java
@@ -94,13 +94,13 @@ public class PacketGetEntityInfo implements IMessage {
     private static ProbeInfo getProbeInfo(EntityPlayer player, ProbeMode mode, World world, Entity entity, Vec3d hitVec) {
         if (Config.needsProbe == PROBE_NEEDEDFOREXTENDED) {
             // We need a probe only for extended information
-            if (!ModItems.hasAProbeSomewhere(player)) {
+            if (!ProbeChecker.hasAProbeSomewhere(player)) {
                 // No probe anywhere, switch EXTENDED to NORMAL
                 if (mode == ProbeMode.EXTENDED) {
                     mode = ProbeMode.NORMAL;
                 }
             }
-        } else if (Config.needsProbe == PROBE_NEEDEDHARD && !ModItems.hasAProbeSomewhere(player)) {
+        } else if (Config.needsProbe == PROBE_NEEDEDHARD && !ProbeChecker.hasAProbeSomewhere(player)) {
             // The server says we need a probe but we don't have one in our hands or on our head
             return null;
         }

--- a/src/main/java/mcjty/theoneprobe/network/PacketGetInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketGetInfo.java
@@ -116,13 +116,13 @@ public class PacketGetInfo implements IMessage {
     private static ProbeInfo getProbeInfo(EntityPlayer player, ProbeMode mode, World world, BlockPos blockPos, EnumFacing sideHit, Vec3d hitVec, ItemStack pickBlock) {
         if (Config.needsProbe == PROBE_NEEDEDFOREXTENDED) {
             // We need a probe only for extended information
-            if (!ModItems.hasAProbeSomewhere(player)) {
+            if (!ProbeChecker.hasAProbeSomewhere(player)) {
                 // No probe anywhere, switch EXTENDED to NORMAL
                 if (mode == ProbeMode.EXTENDED) {
                     mode = ProbeMode.NORMAL;
                 }
             }
-        } else if (Config.needsProbe == PROBE_NEEDEDHARD && !ModItems.hasAProbeSomewhere(player)) {
+        } else if (Config.needsProbe == PROBE_NEEDEDHARD && !ProbeChecker.hasAProbeSomewhere(player)) {
             // The server says we need a probe but we don't have one in our hands
             return null;
         }

--- a/src/main/java/mcjty/theoneprobe/proxy/ClientProxy.java
+++ b/src/main/java/mcjty/theoneprobe/proxy/ClientProxy.java
@@ -1,5 +1,6 @@
 package mcjty.theoneprobe.proxy;
 
+import mcjty.theoneprobe.api.ProbeChecker;
 import mcjty.theoneprobe.api.ProbeMode;
 import mcjty.theoneprobe.commands.CommandTopCfg;
 import mcjty.theoneprobe.config.Config;
@@ -99,7 +100,7 @@ public class ClientProxy extends CommonProxy {
                     break;
                 case PROBE_NEEDED:
                 case PROBE_NEEDEDHARD:
-                    if (ModItems.hasAProbeSomewhere(Minecraft.getMinecraft().thePlayer)) {
+                    if (ProbeChecker.hasAProbeSomewhere(Minecraft.getMinecraft().thePlayer)) {
                         OverlayRenderer.renderHUD(getModeForPlayer(), event.getPartialTicks());
                     }
                     break;


### PR DESCRIPTION
Hi, I've create less hardcoded API based on `IProbeItem` and `IProbeCheck` interfaces
`IProbeItem` allows you  to easily create new probe, all existing checks are adapted to it (even bauble check, that previously can only see goggles).
`IProbeChek` allows to create new checks, for example you have some "Probe block", and you want to show info if player linked to it, so you just write `ProbeChecker.addCheck(p -> ProbeLinkingManager.isPlayerLinked(p));`

I also created this api for 1.11, but github doesn't allow to send two branches in one pull requrest.