### PR TITLE
DefaultProbeInfoProvider shows what mobs spawner spawns

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProbeConfig.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeConfig.java
@@ -41,6 +41,9 @@ public interface IProbeConfig {
     IProbeConfig showBrewStandSetting(ConfigMode mode);
     ConfigMode getShowBrewStandSetting();
 
+    IProbeConfig showMobSpawnerSetting(ConfigMode mode);
+    ConfigMode getShowMobSpawnerSetting();
+
     IProbeConfig showTankSetting(ConfigMode mode);
     ConfigMode getShowTankSetting();
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/LazyProbeConfig.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/LazyProbeConfig.java
@@ -29,6 +29,7 @@ public class LazyProbeConfig implements IProbeConfig {
                     .showLeverSetting(original.getShowLeverSetting())
                     .showTankSetting(original.getShowTankSetting())
                     .showBrewStandSetting(original.getShowBrewStandSetting())
+                    .showMobSpawnerSetting(original.getShowMobSpawnerSetting())
                     .showAnimalOwnerSetting(original.getAnimalOwnerSetting())
                     .showHorseStatSetting(original.getHorseStatSetting());
         }
@@ -66,6 +67,17 @@ public class LazyProbeConfig implements IProbeConfig {
     @Override
     public ConfigMode getAnimalOwnerSetting() {
         return original.getAnimalOwnerSetting();
+    }
+
+    @Override
+    public IProbeConfig showMobSpawnerSetting(ConfigMode mode) {
+        realCopy().showMobSpawnerSetting(mode);
+        return this;
+    }
+
+    @Override
+    public ConfigMode getShowMobSpawnerSetting() {
+        return original.getShowMobSpawnerSetting();
     }
 
     @Override

--- a/src/main/java/mcjty/theoneprobe/apiimpl/ProbeConfig.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/ProbeConfig.java
@@ -22,6 +22,7 @@ public class ProbeConfig implements IProbeConfig {
     private IProbeConfig.ConfigMode showLeverSetting = NORMAL;
     private IProbeConfig.ConfigMode showTankSetting = EXTENDED;
     private IProbeConfig.ConfigMode showBrewStand = NORMAL;
+    private IProbeConfig.ConfigMode showMobSpawner = NORMAL;
     private IProbeConfig.ConfigMode showMobOwner = EXTENDED;
     private IProbeConfig.ConfigMode showHorseStats = EXTENDED;
 
@@ -83,6 +84,17 @@ public class ProbeConfig implements IProbeConfig {
     @Override
     public ConfigMode getShowBrewStandSetting() {
         return showBrewStand;
+    }
+
+    @Override
+    public IProbeConfig showMobSpawnerSetting(ConfigMode mode) {
+        showMobSpawner = mode;
+        return this;
+    }
+
+    @Override
+    public ConfigMode getShowMobSpawnerSetting() {
+        return showMobSpawner;
     }
 
     @Override

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -14,6 +14,8 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityBrewingStand;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+import net.minecraft.tileentity.MobSpawnerBaseLogic;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.energy.CapabilityEnergy;
@@ -87,6 +89,10 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
         if (Tools.show(mode, config.getShowBrewStandSetting())) {
             showBrewingStandInfo(probeInfo, world, data, block);
         }
+        
+        if (Tools.show(mode, config.getShowMobSpawnerSetting())) {
+            showMobSpawnerInfo(probeInfo, world, data, block);
+        }
     }
 
     private void showBrewingStandInfo(IProbeInfo probeInfo, World world, IProbeHitData data, Block block) {
@@ -102,6 +108,19 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                     probeInfo.text(LABEL + "Time: " + INFO + brewtime + " ticks");
                 }
 
+            }
+        }
+    }
+
+    private void showMobSpawnerInfo(IProbeInfo probeInfo, World world, IProbeHitData data, Block block) {
+        if (block instanceof BlockMobSpawner) {
+            TileEntity te = world.getTileEntity(data.getPos());
+            if (te instanceof TileEntityMobSpawner) {
+                MobSpawnerBaseLogic logic = ((TileEntityMobSpawner) te).getSpawnerBaseLogic();
+                String mobName = logic.getCachedEntity().getName();
+                probeInfo.horizontal(probeInfo.defaultLayoutStyle()
+                    .alignment(ElementAlignment.ALIGN_CENTER))
+                    .text(LABEL + "Mob: " + INFO + mobName);
             }
         }
     }

--- a/src/main/java/mcjty/theoneprobe/config/Config.java
+++ b/src/main/java/mcjty/theoneprobe/config/Config.java
@@ -165,6 +165,7 @@ public class Config {
         defaultConfig.showLeverSetting(IProbeConfig.ConfigMode.values()[cfg.getInt("showLeverSetting", CATEGORY_THEONEPROBE, defaultConfig.getShowLeverSetting().ordinal(), 0, 2, "Show lever/comparator/repeater settings (0 = not, 1 = always, 2 = sneak)")]);
         defaultConfig.showTankSetting(IProbeConfig.ConfigMode.values()[cfg.getInt("showTankSetting", CATEGORY_THEONEPROBE, defaultConfig.getShowTankSetting().ordinal(), 0, 2, "Show tank setting (0 = not, 1 = always, 2 = sneak)")]);
         defaultConfig.showBrewStandSetting(IProbeConfig.ConfigMode.values()[cfg.getInt("showBrewStandSetting", CATEGORY_THEONEPROBE, defaultConfig.getShowBrewStandSetting().ordinal(), 0, 2, "Show brewing stand setting (0 = not, 1 = always, 2 = sneak)")]);
+        defaultConfig.showMobSpawnerSetting(IProbeConfig.ConfigMode.values()[cfg.getInt("showMobSpawnerSetting", CATEGORY_THEONEPROBE, defaultConfig.getShowMobSpawnerSetting().ordinal(), 0, 2, "Show mob spawner setting (0 = not, 1 = always, 2 = sneak)")]);
         defaultConfig.showAnimalOwnerSetting(IProbeConfig.ConfigMode.values()[cfg.getInt("showAnimalOwnerSetting", CATEGORY_THEONEPROBE, defaultConfig.getAnimalOwnerSetting().ordinal(), 0, 2, "Show animal owner setting (0 = not, 1 = always, 2 = sneak)")]);
         defaultConfig.showHorseStatSetting(IProbeConfig.ConfigMode.values()[cfg.getInt("showHorseStatSetting", CATEGORY_THEONEPROBE, defaultConfig.getHorseStatSetting().ordinal(), 0, 2, "Show horse stats setting (0 = not, 1 = always, 2 = sneak)")]);
     }


### PR DESCRIPTION
This PR adds the name of the spawned mob for Mob Spawners to the probe info display, addresses #203 . I also added config options for mob spawner information. Currently there's not much in the display:

![spawner](https://user-images.githubusercontent.com/2351067/32247921-f39a95f6-be51-11e7-8d9d-ddddd2eda3c7.jpg)

I considered adding a progress bar of sorts to show how long until the mob is spawned (there's a 'Delay' tag that stores this information in the blockentity), but didn't figure it out well. If you'd like I can spend some more time and implement this, or other suggestions you have to make it look cool. It'd be cool to put a mob icon there too, but I don't know how to implement that. 