### PR TITLE
Added mob armor visual to the HUD

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
@@ -32,6 +32,8 @@ public interface IProgressStyle {
     IProgressStyle height(int h);
 
     IProgressStyle lifeBar(boolean b);
+    
+    IProgressStyle armorBar(boolean b);
 
     int getBorderColor();
 
@@ -54,4 +56,6 @@ public interface IProgressStyle {
     int getHeight();
 
     boolean isLifeBar();
+
+    boolean isArmorBar();
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
@@ -15,6 +15,8 @@ public class ElementProgressRender {
     public static void render(IProgressStyle style, long current, long max, int x, int y, int w, int h) {
         if (style.isLifeBar()) {
             renderLifeBar(current, x, y, w, h);
+        } else if (style.isArmorBar()) {
+            renderArmorBar(current, x, y, w, h);
         } else {
             RenderHelper.drawThickBeveledBox(x, y, x + w, y + h, 1, style.getBorderColor(), style.getBorderColor(), style.getBackgroundColor());
             if (current > 0 && max > 0) {
@@ -53,6 +55,24 @@ public class ElementProgressRender {
             }
             if (current % 2 != 0) {
                 RenderHelper.drawTexturedModalRect(x, y, 61, 0, 9, 9);
+            }
+        }
+    }
+
+    private static void renderArmorBar(long current, int x, int y, int w, int h) {
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        Minecraft.getMinecraft().getTextureManager().bindTexture(ICONS);
+        if (current * 4 >= w) {
+            // Shortened view
+            RenderHelper.drawTexturedModalRect(x, y, 43, 9, 9, 9);
+            RenderHelper.renderText(Minecraft.getMinecraft(), x + 12, y, TextFormatting.WHITE + String.valueOf((current / 2)));
+        } else {
+            for (int i = 0; i < current / 2; i++) {
+                RenderHelper.drawTexturedModalRect(x, y, 43, 9, 9, 9);
+                x += 8;
+            }
+            if (current % 2 != 0) {
+                RenderHelper.drawTexturedModalRect(x, y, 25, 9, 9, 9);
             }
         }
     }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
@@ -37,7 +37,8 @@ public class ElementProgress implements IElement {
                 .backgroundColor(buf.readInt())
                 .showText(buf.readBoolean())
                 .numberFormat(NumberFormat.values()[buf.readByte()])
-                .lifeBar(buf.readBoolean());
+                .lifeBar(buf.readBoolean())
+                .armorBar(buf.readBoolean());
     }
 
     private static DecimalFormat dfCommas = new DecimalFormat("###,###");
@@ -114,6 +115,7 @@ public class ElementProgress implements IElement {
         buf.writeBoolean(style.isShowText());
         buf.writeByte(style.getNumberFormat().ordinal());
         buf.writeBoolean(style.isLifeBar());
+        buf.writeBoolean(style.isArmorBar());
     }
 
     @Override

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
@@ -56,9 +56,16 @@ public class DefaultProbeInfoEntityProvider implements IProbeInfoEntityProvider 
             if (Tools.show(mode, config.getShowMobHealth())) {
                 int health = (int) livingBase.getHealth();
                 int maxHealth = (int) livingBase.getMaxHealth();
+                int armor = livingBase.getTotalArmorValue();
+
                 probeInfo.progress(health, maxHealth, probeInfo.defaultProgressStyle().lifeBar(true).showText(false).width(150).height(10));
+
                 if (mode == ProbeMode.EXTENDED) {
                     probeInfo.text(LABEL + "Health: " + INFOIMP + health + " / " + maxHealth);
+                }
+
+                if (armor > 0) {
+                    probeInfo.progress(armor, armor, probeInfo.defaultProgressStyle().armorBar(true).showText(false).width(80).height(10));
                 }
             }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/styles/ProgressStyle.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/styles/ProgressStyle.java
@@ -17,6 +17,7 @@ public class ProgressStyle implements IProgressStyle {
     private int width = 100;
     private int height = 12;
     private boolean lifeBar = false;
+    private boolean armorBar = false;
 
     private NumberFormat numberFormat = NumberFormat.FULL;
 
@@ -93,6 +94,12 @@ public class ProgressStyle implements IProgressStyle {
     }
 
     @Override
+    public IProgressStyle armorBar(boolean b) {
+        this.armorBar = b;
+        return this;
+    }
+
+    @Override
     public int getBorderColor() {
         return borderColor;
     }
@@ -145,5 +152,10 @@ public class ProgressStyle implements IProgressStyle {
     @Override
     public boolean isLifeBar() {
         return lifeBar;
+    }
+
+    @Override
+    public boolean isArmorBar() {
+        return armorBar;
     }
 }


### PR DESCRIPTION
Screenshot with partial armor symbols:

![lessarmor](https://user-images.githubusercontent.com/2351067/32260355-616dcf56-be95-11e7-9104-a18c3aaefbd1.jpg)

Screenshot with more armor than we want to render:
![fullarmor](https://user-images.githubusercontent.com/2351067/32260360-6a70086c-be95-11e7-8d5d-76a820b8ecd1.jpg)

I'm open to suggestions if there's another way you want to render the armor or code this feature. I'm not sure if you're willing to accept the API change, but I figured this would be a good place to to discuss it or think of alternatives. 