### PR TITLE
General 1.15 cleanup

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IElement.java
+++ b/src/main/java/mcjty/theoneprobe/api/IElement.java
@@ -27,22 +27,10 @@ public interface IElement {
      * Persist this element to the given network buffer. This should be symmetrical to
      * what IElementFactory.createElement() expects.
      *
-     * @deprecated To be removed in 1.16, prefer implementing and using {@link #toBytes(PacketBuffer)}
-     *
-     * @implNote NO-OPing this method is fine as long as {@link #toBytes(PacketBuffer)} is properly implemented
+     * @deprecated To be removed in 1.16, prefer implementing and using {@link IElementNew#toBytes(PacketBuffer)}
      */
     @Deprecated
-    default void toBytes(ByteBuf buf) {
-        //TODO: 1.16 remove this method, it is being left for binary compatibility for now
-    }
-
-    /**
-     * Persist this element to the given network buffer. This should be symmetrical to
-     * what IElementFactory.createElement() expects.
-     */
-    default void toBytes(PacketBuffer buf) {
-        toBytes((ByteBuf) buf);
-    }
+    void toBytes(ByteBuf buf);
 
     /**
      * Get the identifier for this element (as returned by ITheOneProbe.registerElementFactory()

--- a/src/main/java/mcjty/theoneprobe/api/IElement.java
+++ b/src/main/java/mcjty/theoneprobe/api/IElement.java
@@ -1,6 +1,7 @@
 package mcjty.theoneprobe.api;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
 
 /**
  * An element in the probe gui.
@@ -25,8 +26,23 @@ public interface IElement {
     /**
      * Persist this element to the given network buffer. This should be symmetrical to
      * what IElementFactory.createElement() expects.
+     *
+     * @deprecated To be removed in 1.16, prefer implementing and using {@link #toBytes(PacketBuffer)}
+     *
+     * @implNote NO-OPing this method is fine as long as {@link #toBytes(PacketBuffer)} is properly implemented
      */
-    void toBytes(ByteBuf buf);
+    @Deprecated
+    default void toBytes(ByteBuf buf) {
+        //TODO: 1.16 remove this method, it is being left for binary compatibility for now
+    }
+
+    /**
+     * Persist this element to the given network buffer. This should be symmetrical to
+     * what IElementFactory.createElement() expects.
+     */
+    default void toBytes(PacketBuffer buf) {
+        toBytes((ByteBuf) buf);
+    }
 
     /**
      * Get the identifier for this element (as returned by ITheOneProbe.registerElementFactory()

--- a/src/main/java/mcjty/theoneprobe/api/IElementFactory.java
+++ b/src/main/java/mcjty/theoneprobe/api/IElementFactory.java
@@ -4,12 +4,16 @@ import io.netty.buffer.ByteBuf;
 
 /**
  * A factory for elements
+ *
+ * @deprecated To be removed in 1.16, and replaced with {@link IElementFactoryNew}
  */
-public interface IElementFactory {
+@Deprecated
+public interface IElementFactory {//TODO: 1.16, remove this and replace with IElementFactoryNew
 
     /**
      * Create an element from a network buffer. This should be
      * symmetrical to what IElement.toBytes() creates.
      */
+    @Deprecated
     IElement createElement(ByteBuf buf);
 }

--- a/src/main/java/mcjty/theoneprobe/api/IElementFactoryNew.java
+++ b/src/main/java/mcjty/theoneprobe/api/IElementFactoryNew.java
@@ -15,10 +15,12 @@ public interface IElementFactoryNew extends IElementFactory {
     IElement createElement(PacketBuffer buf);
 
     @Override
+    @Deprecated
     default IElement createElement(ByteBuf buf) {
         if (buf instanceof PacketBuffer) {
             return createElement((PacketBuffer) buf);
+        } else {
+            return createElement(new PacketBuffer(buf));
         }
-        return null;
     }
 }

--- a/src/main/java/mcjty/theoneprobe/api/IElementFactoryNew.java
+++ b/src/main/java/mcjty/theoneprobe/api/IElementFactoryNew.java
@@ -1,0 +1,24 @@
+package mcjty.theoneprobe.api;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
+
+/**
+ * A factory for elements
+ */
+public interface IElementFactoryNew extends IElementFactory {
+
+    /**
+     * Create an element from a network buffer. This should be
+     * symmetrical to what IElement.toBytes() creates.
+     */
+    IElement createElement(PacketBuffer buf);
+
+    @Override
+    default IElement createElement(ByteBuf buf) {
+        if (buf instanceof PacketBuffer) {
+            return createElement((PacketBuffer) buf);
+        }
+        return null;
+    }
+}

--- a/src/main/java/mcjty/theoneprobe/api/IElementNew.java
+++ b/src/main/java/mcjty/theoneprobe/api/IElementNew.java
@@ -1,0 +1,23 @@
+package mcjty.theoneprobe.api;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
+
+public interface IElementNew extends IElement {
+
+    /**
+     * Persist this element to the given network buffer. This should be symmetrical to
+     * what IElementFactory.createElement() expects.
+     */
+    void toBytes(PacketBuffer buf);
+
+    @Override
+    @Deprecated
+    default void toBytes(ByteBuf buf) {
+        if (buf instanceof PacketBuffer) {
+            toBytes((PacketBuffer) buf);
+        } else {
+            toBytes(new PacketBuffer(buf));
+        }
+    }
+}

--- a/src/main/java/mcjty/theoneprobe/api/ITheOneProbe.java
+++ b/src/main/java/mcjty/theoneprobe/api/ITheOneProbe.java
@@ -49,8 +49,19 @@ public interface ITheOneProbe {
     /**
      * Register an element factory.
      * @return an id to use when defining elements using this factory
+     *
+     * @deprecated To be removed in 1.16, prefer implementing and using {@link #registerElementFactory(IElementFactoryNew)}
      */
+    @Deprecated
     int registerElementFactory(IElementFactory factory);
+
+    /**
+     * Register an element factory.
+     * @return an id to use when defining elements using this factory
+     */
+    default int registerElementFactory(IElementFactoryNew factory) {
+        return registerElementFactory((IElementFactory) factory);
+    }
 
     /**
      * Get the element factory for a given ID.

--- a/src/main/java/mcjty/theoneprobe/apiimpl/ProbeInfo.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/ProbeInfo.java
@@ -5,6 +5,7 @@ import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IElementFactory;
 import mcjty.theoneprobe.api.IElementFactoryNew;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.apiimpl.elements.ElementVertical;
 
 import java.util.ArrayList;
@@ -44,7 +45,11 @@ public class ProbeInfo extends ElementVertical {
         buf.writeVarInt(elements.size());
         for (IElement element : elements) {
             buf.writeVarInt(element.getID());
-            element.toBytes(buf);
+            if (element instanceof IElementNew) {
+                ((IElementNew) element).toBytes(buf);
+            } else {
+                element.toBytes(buf);
+            }
         }
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
@@ -12,7 +12,7 @@ import net.minecraft.util.ResourceLocation;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class AbstractElementPanel implements IElement, IProbeInfo {
+public abstract class AbstractElementPanel implements IElementNew, IProbeInfo {
 
     protected List<IElement> children = new ArrayList<>();
     protected Integer borderColor;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
@@ -1,12 +1,12 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.*;
 import mcjty.theoneprobe.apiimpl.ProbeInfo;
 import mcjty.theoneprobe.apiimpl.styles.*;
 import mcjty.theoneprobe.rendering.RenderHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ public abstract class AbstractElementPanel implements IElement, IProbeInfo {
         this.alignment = alignment;
     }
 
-    public AbstractElementPanel(ByteBuf buf) {
+    public AbstractElementPanel(PacketBuffer buf) {
         children = ProbeInfo.createElements(buf);
         if (buf.readBoolean()) {
             borderColor = buf.readInt();
@@ -48,7 +48,7 @@ public abstract class AbstractElementPanel implements IElement, IProbeInfo {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         ProbeInfo.writeElements(children, buf);
         if (borderColor != null) {
             buf.writeBoolean(true);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementEntity.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementEntity.java
@@ -1,6 +1,6 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.api.IEntityStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementEntityRender;
@@ -13,7 +13,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.registries.ForgeRegistries;
 
-public class ElementEntity implements IElement {
+public class ElementEntity implements IElementNew {
 
     private final String entityName;
     private final Integer playerID;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementEntity.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementEntity.java
@@ -1,6 +1,5 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IEntityStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
@@ -10,6 +9,7 @@ import mcjty.theoneprobe.network.NetworkTools;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -45,17 +45,13 @@ public class ElementEntity implements IElement {
         this.style = style;
     }
 
-    public ElementEntity(ByteBuf buf) {
+    public ElementEntity(PacketBuffer buf) {
         entityName = NetworkTools.readString(buf);
         style = new EntityStyle()
                 .width(buf.readInt())
                 .height(buf.readInt())
                 .scale(buf.readFloat());
-        if (buf.readBoolean()) {
-            entityNBT = NetworkTools.readNBT(buf);
-        } else {
-            entityNBT = null;
-        }
+        entityNBT = buf.readCompoundTag();
         if (buf.readBoolean()) {
             playerID = buf.readInt();
         } else {
@@ -83,17 +79,12 @@ public class ElementEntity implements IElement {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         NetworkTools.writeString(buf, entityName);
         buf.writeInt(style.getWidth());
         buf.writeInt(style.getHeight());
         buf.writeFloat(style.getScale());
-        if (entityNBT != null) {
-            buf.writeBoolean(true);
-            NetworkTools.writeNBT(buf, entityNBT);
-        } else {
-            buf.writeBoolean(false);
-        }
+        buf.writeCompoundTag(entityNBT);
         if (playerID != null) {
             buf.writeBoolean(true);
             buf.writeInt(playerID);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementHorizontal.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementHorizontal.java
@@ -1,9 +1,9 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import net.minecraft.network.PacketBuffer;
 
 public class ElementHorizontal extends AbstractElementPanel {
 
@@ -13,7 +13,7 @@ public class ElementHorizontal extends AbstractElementPanel {
         super(borderColor, spacing, alignment);
     }
 
-    public ElementHorizontal(ByteBuf buf) {
+    public ElementHorizontal(PacketBuffer buf) {
         super(buf);
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
@@ -1,6 +1,6 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.api.IIconStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementIconRender;
@@ -8,7 +8,7 @@ import mcjty.theoneprobe.apiimpl.styles.IconStyle;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 
-public class ElementIcon implements IElement {
+public class ElementIcon implements IElementNew {
 
     private final ResourceLocation icon;
     private final int u;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
@@ -1,12 +1,11 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IIconStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementIconRender;
 import mcjty.theoneprobe.apiimpl.styles.IconStyle;
-import mcjty.theoneprobe.network.NetworkTools;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 
 public class ElementIcon implements IElement {
@@ -27,8 +26,8 @@ public class ElementIcon implements IElement {
         this.style = style;
     }
 
-    public ElementIcon(ByteBuf buf) {
-        icon = new ResourceLocation(NetworkTools.readString(buf), NetworkTools.readString(buf));
+    public ElementIcon(PacketBuffer buf) {
+        icon = buf.readResourceLocation();
         u = buf.readInt();
         v = buf.readInt();
         w = buf.readInt();
@@ -56,9 +55,8 @@ public class ElementIcon implements IElement {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
-        NetworkTools.writeString(buf, icon.getNamespace());
-        NetworkTools.writeString(buf, icon.getPath());
+    public void toBytes(PacketBuffer buf) {
+        buf.writeResourceLocation(icon);
         buf.writeInt(u);
         buf.writeInt(v);
         buf.writeInt(w);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemLabel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemLabel.java
@@ -1,11 +1,11 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
 import mcjty.theoneprobe.network.NetworkTools;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
 
 public class ElementItemLabel implements IElement {
 
@@ -15,7 +15,7 @@ public class ElementItemLabel implements IElement {
         this.itemStack = itemStack;
     }
 
-    public ElementItemLabel(ByteBuf buf) {
+    public ElementItemLabel(PacketBuffer buf) {
         if (buf.readBoolean()) {
             itemStack = NetworkTools.readItemStack(buf);
         } else {
@@ -47,7 +47,7 @@ public class ElementItemLabel implements IElement {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         if (!itemStack.isEmpty()) {
             buf.writeBoolean(true);
             NetworkTools.writeItemStack(buf, itemStack);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemLabel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemLabel.java
@@ -1,13 +1,13 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
 import mcjty.theoneprobe.network.NetworkTools;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 
-public class ElementItemLabel implements IElement {
+public class ElementItemLabel implements IElementNew {
 
     private final ItemStack itemStack;
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemStack.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemStack.java
@@ -1,6 +1,5 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IItemStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
@@ -8,6 +7,7 @@ import mcjty.theoneprobe.apiimpl.client.ElementItemStackRender;
 import mcjty.theoneprobe.apiimpl.styles.ItemStyle;
 import mcjty.theoneprobe.network.NetworkTools;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
 
 public class ElementItemStack implements IElement {
 
@@ -19,7 +19,7 @@ public class ElementItemStack implements IElement {
         this.style = style;
     }
 
-    public ElementItemStack(ByteBuf buf) {
+    public ElementItemStack(PacketBuffer buf) {
         if (buf.readBoolean()) {
             itemStack = NetworkTools.readItemStack(buf);
         } else {
@@ -46,7 +46,7 @@ public class ElementItemStack implements IElement {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         if (!itemStack.isEmpty()) {
             buf.writeBoolean(true);
             NetworkTools.writeItemStack(buf, itemStack);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemStack.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementItemStack.java
@@ -1,6 +1,6 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.api.IItemStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementItemStackRender;
@@ -9,7 +9,7 @@ import mcjty.theoneprobe.network.NetworkTools;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 
-public class ElementItemStack implements IElement {
+public class ElementItemStack implements IElementNew {
 
     private final ItemStack itemStack;
     private final IItemStyle style;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
@@ -1,6 +1,6 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.api.IProgressStyle;
 import mcjty.theoneprobe.api.NumberFormat;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
@@ -11,7 +11,7 @@ import mcjty.theoneprobe.network.NetworkTools;
 import java.text.DecimalFormat;
 import net.minecraft.network.PacketBuffer;
 
-public class ElementProgress implements IElement {
+public class ElementProgress implements IElementNew {
 
     private final long current;
     private final long max;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
@@ -1,6 +1,5 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IProgressStyle;
 import mcjty.theoneprobe.api.NumberFormat;
@@ -10,6 +9,7 @@ import mcjty.theoneprobe.apiimpl.styles.ProgressStyle;
 import mcjty.theoneprobe.network.NetworkTools;
 
 import java.text.DecimalFormat;
+import net.minecraft.network.PacketBuffer;
 
 public class ElementProgress implements IElement {
 
@@ -23,7 +23,7 @@ public class ElementProgress implements IElement {
         this.style = style;
     }
 
-    public ElementProgress(ByteBuf buf) {
+    public ElementProgress(PacketBuffer buf) {
         current = buf.readLong();
         max = buf.readLong();
         style = new ProgressStyle()
@@ -101,7 +101,7 @@ public class ElementProgress implements IElement {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         buf.writeLong(current);
         buf.writeLong(max);
         buf.writeInt(style.getWidth());

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementText.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementText.java
@@ -1,10 +1,10 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
 import mcjty.theoneprobe.network.NetworkTools;
+import net.minecraft.network.PacketBuffer;
 
 public class ElementText implements IElement {
 
@@ -14,7 +14,7 @@ public class ElementText implements IElement {
         this.text = text;
     }
 
-    public ElementText(ByteBuf buf) {
+    public ElementText(PacketBuffer buf) {
         text = NetworkTools.readStringUTF8(buf);
     }
 
@@ -34,7 +34,7 @@ public class ElementText implements IElement {
     }
 
     @Override
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         NetworkTools.writeStringUTF8(buf, text);
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementText.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementText.java
@@ -1,12 +1,12 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementNew;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
 import mcjty.theoneprobe.network.NetworkTools;
 import net.minecraft.network.PacketBuffer;
 
-public class ElementText implements IElement {
+public class ElementText implements IElementNew {
 
     private final String text;
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementVertical.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementVertical.java
@@ -1,9 +1,9 @@
 package mcjty.theoneprobe.apiimpl.elements;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import net.minecraft.network.PacketBuffer;
 
 public class ElementVertical extends AbstractElementPanel {
 
@@ -13,7 +13,7 @@ public class ElementVertical extends AbstractElementPanel {
         super(borderColor, spacing, alignment);
     }
 
-    public ElementVertical(ByteBuf buf) {
+    public ElementVertical(PacketBuffer buf) {
         super(buf);
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -9,6 +9,7 @@ import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import mcjty.theoneprobe.compat.TeslaTools;
 import mcjty.theoneprobe.config.Config;
 import net.minecraft.block.*;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
@@ -29,6 +30,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 
 import java.util.Collections;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import static mcjty.theoneprobe.api.IProbeInfo.ENDLOC;
 import static mcjty.theoneprobe.api.IProbeInfo.STARTLOC;
@@ -123,10 +125,13 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
             TileEntity te = world.getTileEntity(data.getPos());
             if (te instanceof MobSpawnerTileEntity) {
                 AbstractSpawner logic = ((MobSpawnerTileEntity) te).getSpawnerBaseLogic();
-                String mobName = logic.getCachedEntity().getDisplayName().getFormattedText();
-                probeInfo.horizontal(probeInfo.defaultLayoutStyle()
-                    .alignment(ElementAlignment.ALIGN_CENTER))
-                    .text(LABEL + "Mob: " + INFO + mobName);
+                EntityType<?> type = ForgeRegistries.ENTITIES.getValue(logic.getEntityId());
+                if (type != null) {
+                    String mobName = type.getName().getFormattedText();
+                    probeInfo.horizontal(probeInfo.defaultLayoutStyle()
+                          .alignment(ElementAlignment.ALIGN_CENTER))
+                          .text(LABEL + "Mob: " + INFO + mobName);
+                }
             }
         }
     }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -107,8 +107,8 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
         if (block instanceof BrewingStandBlock) {
             TileEntity te = world.getTileEntity(data.getPos());
             if (te instanceof BrewingStandTileEntity) {
-                int brewtime = 0; // @todo 1.14 ((BrewingStandTileEntity) te).getField(0);
-                int fuel = 0; // @todo 1.14 ((BrewingStandTileEntity) te).getField(1);
+                int brewtime = ((BrewingStandTileEntity) te).brewTime;
+                int fuel = ((BrewingStandTileEntity) te).fuel;
                 probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
                         .item(new ItemStack(Items.BLAZE_POWDER), probeInfo.defaultItemStyle().width(16).height(16))
                         .text(LABEL + "Fuel: " + INFO + fuel);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -11,6 +11,7 @@ import mcjty.theoneprobe.config.Config;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.IFluidState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -175,7 +176,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                 for (int i = 0 ; i < handler.getTanks() ; i++) {
                     FluidStack fluidStack = handler.getFluidInTank(i);
                     int maxContents = handler.getTankCapacity(i);
-                    if (fluidStack != null) {
+                    if (!fluidStack.isEmpty()) {
                         addFluidInfo(probeInfo, config, fluidStack, maxContents);
                     }
                 }
@@ -184,8 +185,8 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
     }
 
     private void addFluidInfo(IProbeInfo probeInfo, ProbeConfig config, FluidStack fluidStack, int maxContents) {
-        int contents = fluidStack == null ? 0 : fluidStack.getAmount();
-        if (fluidStack != null) {
+        int contents = fluidStack.getAmount();
+        if (!fluidStack.isEmpty()) {
             probeInfo.text(NAME + "Liquid:" + STARTLOC + fluidStack.getTranslationKey() + ENDLOC);
         }
         if (config.getTankMode() == 1) {
@@ -266,7 +267,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
         if (block instanceof FlowingFluidBlock) {
             IFluidState fluidState = block.getFluidState(blockState);
             Fluid fluid = fluidState.getFluid();
-            if (fluid != null) {
+            if (fluid != Fluids.EMPTY) {
                 FluidStack fluidStack = new FluidStack(fluid.getFluid(), BUCKET_VOLUME);
                 ItemStack bucketStack = FluidUtil.getFilledBucket(fluidStack);
 

--- a/src/main/java/mcjty/theoneprobe/config/Config.java
+++ b/src/main/java/mcjty/theoneprobe/config/Config.java
@@ -3,7 +3,6 @@ package mcjty.theoneprobe.config;
 
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.io.WritingMode;
-import com.google.common.collect.Lists;
 import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.api.IOverlayStyle;
 import mcjty.theoneprobe.api.IProbeConfig;
@@ -270,14 +269,14 @@ public class Config {
                 .defineInRange("showSmallChestContentsWithoutSneaking", 0, 0, 1000);
         showContentsWithoutSneaking = COMMON_BUILDER
                 .comment("A list of blocks for which we automatically show chest contents even if not sneaking")
-                .define("showContentsWithoutSneaking", Lists.<String>asList("storagedrawers:basicdrawers", new String[] { "storagedrawersextra:extra_drawers" }));
+                .define("showContentsWithoutSneaking", new ArrayList<>(Arrays.asList("storagedrawers:basicdrawers", "storagedrawersextra:extra_drawers")));
         dontShowContentsUnlessSneaking = COMMON_BUILDER
                 .comment("A list of blocks for which we don't show chest contents automatically except if sneaking")
-                .define("dontShowContentsUnlessSneaking", Collections.emptyList());
+                .define("dontShowContentsUnlessSneaking", new ArrayList<>());
 
         dontSendNBT = COMMON_BUILDER
                 .comment("A list of blocks for which we don't send NBT over the network. This is mostly useful for blocks that have HUGE NBT in their pickblock (itemstack)")
-                .define("dontSendNBT", Collections.emptyList());
+                .define("dontSendNBT", new ArrayList<>());
 
         setupStyleConfig();
 

--- a/src/main/java/mcjty/theoneprobe/network/PacketGetEntityInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketGetEntityInfo.java
@@ -1,6 +1,5 @@
 package mcjty.theoneprobe.network;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.api.*;
 import mcjty.theoneprobe.apiimpl.ProbeHitEntityData;
@@ -9,6 +8,7 @@ import mcjty.theoneprobe.config.Config;
 import mcjty.theoneprobe.items.ModItems;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
@@ -35,19 +35,18 @@ public class PacketGetEntityInfo {
     private ProbeMode mode;
     private Vec3d hitVec;
 
-    public PacketGetEntityInfo(ByteBuf buf) {
+    public PacketGetEntityInfo(PacketBuffer buf) {
         dim = buf.readInt();
-        uuid = new UUID(buf.readLong(), buf.readLong());
+        uuid = buf.readUniqueId();
         mode = ProbeMode.values()[buf.readByte()];
         if (buf.readBoolean()) {
             hitVec = new Vec3d(buf.readDouble(), buf.readDouble(), buf.readDouble());
         }
     }
 
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         buf.writeInt(dim);
-        buf.writeLong(uuid.getMostSignificantBits());
-        buf.writeLong(uuid.getLeastSignificantBits());
+        buf.writeUniqueId(uuid);
         buf.writeByte(mode.ordinal());
         if (hitVec == null) {
             buf.writeBoolean(false);

--- a/src/main/java/mcjty/theoneprobe/network/PacketGetInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketGetInfo.java
@@ -41,8 +41,8 @@ public class PacketGetInfo  {
     private ItemStack pickBlock;
 
     public PacketGetInfo(PacketBuffer buf) {
-        dim = DimensionType.getById(buf.readInt());
-        pos = new BlockPos(buf.readInt(), buf.readInt(), buf.readInt());
+        dim = DimensionType.byName(buf.readResourceLocation());
+        pos = buf.readBlockPos();
         mode = ProbeMode.values()[buf.readByte()];
         byte sideByte = buf.readByte();
         if (sideByte == 127) {
@@ -57,10 +57,8 @@ public class PacketGetInfo  {
     }
 
     public void toBytes(PacketBuffer buf) {
-        buf.writeInt(dim.getId());
-        buf.writeInt(pos.getX());
-        buf.writeInt(pos.getY());
-        buf.writeInt(pos.getZ());
+        buf.writeResourceLocation(dim.getRegistryName());
+        buf.writeBlockPos(pos);
         buf.writeByte(mode.ordinal());
         buf.writeByte(sideHit == null ? 127 : sideHit.ordinal());
         if (hitVec == null) {

--- a/src/main/java/mcjty/theoneprobe/network/PacketReturnEntityInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketReturnEntityInfo.java
@@ -1,8 +1,8 @@
 package mcjty.theoneprobe.network;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.apiimpl.ProbeInfo;
 import mcjty.theoneprobe.rendering.OverlayRenderer;
+import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.network.NetworkEvent;
 
 import java.util.UUID;
@@ -13,8 +13,8 @@ public class PacketReturnEntityInfo {
     private UUID uuid;
     private ProbeInfo probeInfo;
 
-    public PacketReturnEntityInfo(ByteBuf buf) {
-        uuid = new UUID(buf.readLong(), buf.readLong());
+    public PacketReturnEntityInfo(PacketBuffer buf) {
+        uuid = buf.readUniqueId();
         if (buf.readBoolean()) {
             probeInfo = new ProbeInfo();
             probeInfo.fromBytes(buf);
@@ -23,9 +23,8 @@ public class PacketReturnEntityInfo {
         }
     }
 
-    public void toBytes(ByteBuf buf) {
-        buf.writeLong(uuid.getMostSignificantBits());
-        buf.writeLong(uuid.getLeastSignificantBits());
+    public void toBytes(PacketBuffer buf) {
+        buf.writeUniqueId(uuid);
         if (probeInfo != null) {
             buf.writeBoolean(true);
             probeInfo.toBytes(buf);

--- a/src/main/java/mcjty/theoneprobe/network/PacketReturnInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketReturnInfo.java
@@ -16,7 +16,7 @@ public class PacketReturnInfo {
     private ProbeInfo probeInfo;
 
     public PacketReturnInfo(PacketBuffer buf) {
-        dim = DimensionType.getById(buf.readInt());
+        dim = DimensionType.byName(buf.readResourceLocation());
         pos = buf.readBlockPos();
         if (buf.readBoolean()) {
             probeInfo = new ProbeInfo();
@@ -27,7 +27,7 @@ public class PacketReturnInfo {
     }
 
     public void toBytes(PacketBuffer buf) {
-        buf.writeInt(dim.getId());
+        buf.writeResourceLocation(dim.getRegistryName());
         buf.writeBlockPos(pos);
         if (probeInfo != null) {
             buf.writeBoolean(true);

--- a/src/main/java/mcjty/theoneprobe/network/PacketReturnInfo.java
+++ b/src/main/java/mcjty/theoneprobe/network/PacketReturnInfo.java
@@ -1,8 +1,8 @@
 package mcjty.theoneprobe.network;
 
-import io.netty.buffer.ByteBuf;
 import mcjty.theoneprobe.apiimpl.ProbeInfo;
 import mcjty.theoneprobe.rendering.OverlayRenderer;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraftforge.fml.network.NetworkEvent;
@@ -15,9 +15,9 @@ public class PacketReturnInfo {
     private BlockPos pos;
     private ProbeInfo probeInfo;
 
-    public PacketReturnInfo(ByteBuf buf) {
+    public PacketReturnInfo(PacketBuffer buf) {
         dim = DimensionType.getById(buf.readInt());
-        pos = new BlockPos(buf.readInt(), buf.readInt(), buf.readInt());
+        pos = buf.readBlockPos();
         if (buf.readBoolean()) {
             probeInfo = new ProbeInfo();
             probeInfo.fromBytes(buf);
@@ -26,11 +26,9 @@ public class PacketReturnInfo {
         }
     }
 
-    public void toBytes(ByteBuf buf) {
+    public void toBytes(PacketBuffer buf) {
         buf.writeInt(dim.getId());
-        buf.writeInt(pos.getX());
-        buf.writeInt(pos.getY());
-        buf.writeInt(pos.getZ());
+        buf.writeBlockPos(pos);
         if (probeInfo != null) {
             buf.writeBoolean(true);
             probeInfo.toBytes(buf);

--- a/src/main/java/mcjty/theoneprobe/rendering/OverlayRenderer.java
+++ b/src/main/java/mcjty/theoneprobe/rendering/OverlayRenderer.java
@@ -208,7 +208,7 @@ public class OverlayRenderer {
     }
 
     private static void requestEntityInfo(ProbeMode mode, RayTraceResult mouseOver, Entity entity, PlayerEntity player) {
-        PacketHandler.INSTANCE.sendToServer(new PacketGetEntityInfo(player.getEntityWorld().getDimension().getType().getId(), mode, mouseOver, entity));
+        PacketHandler.INSTANCE.sendToServer(new PacketGetEntityInfo(player.getEntityWorld().getDimension().getType(), mode, mouseOver, entity));
     }
 
     private static void renderHUDBlock(MatrixStack matrixStack, ProbeMode mode, RayTraceResult mouseOver, double sw, double sh) {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -2,6 +2,8 @@
 public net.minecraft.block.BlockCrops func_185527_x(Lnet/minecraft/block/state/BlockState;)I # getAge
 public net.minecraft.client.multiplayer.PlayerController field_78770_f # curBlockDamageMP
 public net.minecraft.item.ItemTool field_77862_b # toolMaterial
+public net.minecraft.tileentity.BrewingStandTileEntity field_145946_k # brewTime
+public net.minecraft.tileentity.BrewingStandTileEntity field_184278_m # fuel
 public net.minecraft.world.spawner.AbstractSpawner func_190895_g()Lnet/minecraft/util/ResourceLocation; # getEntityId
 
 # For McJtyLib

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -2,6 +2,7 @@
 public net.minecraft.block.BlockCrops func_185527_x(Lnet/minecraft/block/state/BlockState;)I # getAge
 public net.minecraft.client.multiplayer.PlayerController field_78770_f # curBlockDamageMP
 public net.minecraft.item.ItemTool field_77862_b # toolMaterial
+public net.minecraft.world.spawner.AbstractSpawner func_190895_g()Lnet/minecraft/util/ResourceLocation; # getEntityId
 
 # For McJtyLib
 public net.minecraft.inventory.container.Container field_75149_d # listeners


### PR DESCRIPTION
Fixed a few different issues, and switch to using PacketBuffer rather than ByteBuf, maintaining backwards compatibility.

- Fixed checking fluids against null instead of empty as fluids are now like items and are nonnull as of the rewritten fluid APi in 1.14+
- Fixed mob spawner using a client side only method causing it to show an error when looking at spawners on servers (uses an AT)
- Fixed brewing stand information not showing and having a TODO (uses an AT)
- Fixed a few confg options getting reset for being invalid on client restart due to the default implementation without object validator only properly supporting ArrayLists
- Switched from ByteBuf to PacketBuffer to allow for making use of the util methods that Mojang and Forge both add. Maintains backwards compat, by deprecating the old methods and default rerouting the new ones to calling the old one by default. Also adds some TODOs to clean it up in 1.16 by removing the old ByteBuf variants from the API
- Send dimension type by registry name rather than int id to ensure that they match on both the client and server