### PR TITLE
Fix compat with forge 32.0.67

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ github_project=McJtyMods/TheOneProbe
 
 mcp_mappings=20200514-1.16
 minecraft_version=1.16.1
-forge_version=32.0.57
+forge_version=32.0.67
 
 jei_version=1.15.2:6.0.0.2
 patchouli_version=1.15.2-1.2-34.177

--- a/src/main/java/mcjty/theoneprobe/ForgeEventHandlers.java
+++ b/src/main/java/mcjty/theoneprobe/ForgeEventHandlers.java
@@ -12,15 +12,15 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 
 public class ForgeEventHandlers {
 
     @SubscribeEvent
-    public void serverLoad(FMLServerStartingEvent event) {
-        ModCommands.register(event.getCommandDispatcher());
+    public void registerCommands(RegisterCommandsEvent event) {
+        ModCommands.register(event.getDispatcher());
     }
 
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -27,7 +27,7 @@ probe required if you so desire.
 [[dependencies.theoneprobe]] #optional
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[32,)" #mandatory
+    versionRange="[32.0.67,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER


### PR DESCRIPTION
The way commands are registered changed in forge `32.0.67` so that they get properly re-registered when `/reload` is ran.