### PR TITLE
Show two decimals for horse speed and jump values

### DIFF
--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
@@ -37,7 +37,7 @@ public class DefaultProbeInfoEntityProvider implements IProbeInfoEntityProvider 
         return TheOneProbe.MODID + ":entity.default";
     }
 
-    private static DecimalFormat dfCommas = new DecimalFormat("##.#");
+    private static DecimalFormat dfCommas = new DecimalFormat("##.##");
 
     @Override
     public void addProbeEntityInfo(ProbeMode mode, IProbeInfo probeInfo, PlayerEntity player, World world, Entity entity, IProbeHitEntityData data) {


### PR DESCRIPTION
Show two decimals for horse speed and jump values so breeding is easier and more precise. One decimal is just not enough, specially for speed values since the range between min and max horse speed values is too short (0.1125 to 0.3375) with DecimalFormat rounding making even harder to work with horse breeding. Solves issue #320 