### PR TITLE
Fixing Baubles Compat

### DIFF
--- a/src/main/resources/data/theoneprobe/recipes/probegoggles.json
+++ b/src/main/resources/data/theoneprobe/recipes/probegoggles.json
@@ -13,14 +13,13 @@
     "gpg",
     " g "
   ],
-  "type": "forge:ore_shaped",
+  "type": "minecraft:crafting_shaped",
   "key": {
     "p": {
       "item": "theoneprobe:probe"
     },
     "g": {
-      "type": "forge:ore_dict",
-      "ore": "nuggetGold"
+      "tag": "forge:nuggets/gold"
     }
   }
 }


### PR DESCRIPTION
Oredict isn't a thing in 1.16.x
Everything is done by tags. Tags are a better implementation of OreDict.