### PR TITLE
Use mod name instead of mod id

### DIFF
--- a/src/main/java/mcjty/theoneprobe/Tools.java
+++ b/src/main/java/mcjty/theoneprobe/Tools.java
@@ -2,33 +2,22 @@ package mcjty.theoneprobe;
 
 import mcjty.theoneprobe.api.IProbeConfig;
 import mcjty.theoneprobe.api.ProbeMode;
-import net.minecraft.block.Block;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.text.WordUtils;
-
-import java.util.Locale;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+import org.apache.commons.lang3.StringUtils;
 
 import static mcjty.theoneprobe.api.IProbeConfig.ConfigMode.EXTENDED;
 import static mcjty.theoneprobe.api.IProbeConfig.ConfigMode.NORMAL;
 
 public class Tools {
 
-    public static String getModName(Block block) {
-        ResourceLocation itemResourceLocation = block.getRegistryName();
-        String modId = itemResourceLocation.getNamespace();
-        String lowercaseModId = modId.toLowerCase(Locale.ENGLISH);
-        String modName = WordUtils.capitalize(modId);
-        return modName;
-    }
-
-    public static String getModName(Entity entity) {
-        EntityType<?> type = entity.getType();
-        if (type.getRegistryName() == null) {
-            return "Minecraft";
-        }
-        return WordUtils.capitalize(type.getRegistryName().getNamespace());
+    public static String getModName(IForgeRegistryEntry<?> entry) {
+        ResourceLocation registryName = entry.getRegistryName();
+        String modId = registryName == null ? "minecraft" : registryName.getNamespace();
+        return ModList.get().getModContainerById(modId)
+                .map(mod -> mod.getModInfo().getDisplayName())
+                .orElse(StringUtils.capitalize(modId));
     }
 
     public static boolean show(ProbeMode mode, IProbeConfig.ConfigMode cfg) {

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
@@ -175,14 +175,14 @@ public class DefaultProbeInfoEntityProvider implements IProbeInfoEntityProvider 
     }
 
     public static void showStandardInfo(ProbeMode mode, IProbeInfo probeInfo, Entity entity, IProbeConfig config) {
-        String modid = Tools.getModName(entity);
+        String modName = Tools.getModName(entity.getType());
 
         if (Tools.show(mode, config.getShowModName())) {
             probeInfo.horizontal()
                     .entity(entity)
                     .vertical()
                     .text(CompoundText.create().name(entity.getName()))
-                    .text(CompoundText.create().style(MODNAME).text(modid));
+                    .text(CompoundText.create().style(MODNAME).text(modName));
         } else {
             probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
                     .entity(entity)

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -259,7 +259,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
 
     public static void showStandardBlockInfo(IProbeConfig config, ProbeMode mode, IProbeInfo probeInfo, BlockState blockState, Block block, World world,
                                              BlockPos pos, PlayerEntity player, IProbeHitData data) {
-        String modid = Tools.getModName(block);
+        String modName = Tools.getModName(block);
 
         ItemStack pickBlock = data.getPickBlock();
 
@@ -286,7 +286,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
 
                 horizontal.vertical()
                         .text(CompoundText.create().name(fluidStack.getTranslationKey()))
-                        .text(CompoundText.create().style(MODNAME).text(modid));
+                        .text(CompoundText.create().style(MODNAME).text(modName));
                 return;
             }
         }
@@ -297,7 +297,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                         .item(pickBlock)
                         .vertical()
                         .itemLabel(pickBlock)
-                        .text(CompoundText.create().style(MODNAME).text(modid));
+                        .text(CompoundText.create().style(MODNAME).text(modName));
             } else {
                 probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
                         .item(pickBlock)
@@ -307,7 +307,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
             if (Tools.show(mode, config.getShowModName())) {
                 probeInfo.vertical()
                         .text(CompoundText.create().name(block.getTranslationKey()))
-                        .text(CompoundText.create().style(MODNAME).text(modid));
+                        .text(CompoundText.create().style(MODNAME).text(modName));
             } else {
                 probeInfo.vertical()
                         .text(CompoundText.create().name(block.getTranslationKey()));

--- a/src/main/java/mcjty/theoneprobe/gui/GuiConfig.java
+++ b/src/main/java/mcjty/theoneprobe/gui/GuiConfig.java
@@ -200,14 +200,14 @@ public class GuiConfig extends Screen {
 
     private void renderProbe(MatrixStack matrixStack) {
         Block block = Blocks.OAK_LOG;
-        String modid = Tools.getModName(block);
+        String modName = Tools.getModName(block);
         ProbeInfo probeInfo = TheOneProbe.theOneProbeImp.create();
         ItemStack pickBlock = new ItemStack(block);
         probeInfo.horizontal()
                 .item(pickBlock)
                 .vertical()
                 .text(CompoundText.create().name(pickBlock.getTranslationKey()))
-                .text(CompoundText.create().style(MODNAME).text(modid));
+                .text(CompoundText.create().style(MODNAME).text(modName));
         probeInfo.text(CompoundText.createLabelInfo("Fuel: ","5 volts"));
         probeInfo.text(CompoundText.create().style(LABEL).text("Error: ").style(ERROR).text("Oups!"));
 


### PR DESCRIPTION
Title. Small fix to use the mod name for the information tooltips instead of using a capitalized version of the mod id