### PR TITLE
Fixes & Additions to Progressbar.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
@@ -1,61 +1,101 @@
 package mcjty.theoneprobe.api;
 
+import java.awt.Color;
+
+import mcjty.theoneprobe.apiimpl.styles.ProgressStyle;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+
 /**
  * Style for the progress bar.
  */
 public interface IProgressStyle {
+	
+	public static IProgressStyle createDefault() { return new ProgressStyle(); }
+	public static IProgressStyle createArmor() { return new ProgressStyle().armorBar(true); }
+	public static IProgressStyle createLife() { return new ProgressStyle().lifeBar(true); }
+	public static IProgressStyle createAligned(ElementAlignment align) { return new ProgressStyle().alignment(align); }
+	public static IProgressStyle createBounds(int width, int height) { return new ProgressStyle().bounds(width, height); }
+	public static IProgressStyle createTextOnly(String prefix) { return new ProgressStyle().prefix(prefix).numberFormat(NumberFormat.NONE); }
+	public static IProgressStyle createText(String prefix, String suffix) { return new ProgressStyle().prefix(prefix).suffix(suffix); }
+	public static IProgressStyle createText(String prefix, String suffix, NumberFormat format) { return new ProgressStyle().showText(true).prefix(prefix).suffix(suffix).numberFormat(format); }
+	public static IProgressStyle createColored(Color border, Color filledColor, Color background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createColored(Color border, Color filledColor, Color alternate, Color background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createColored(int border, int filledColor, int background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createColored(int border, int filledColor, int alternate, int background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createBorderlessColored(Color filledColor, Color background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createBorderlessColored(Color filledColor, Color alternate, Color background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createBorderlessColored(int filledColor, int background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createBorderlessColored(int filledColor, int alternate, int background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, Color border, Color filledColor, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, Color border, Color filledColor, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, int border, int filledColor, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, int border, int filledColor, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, Color border, Color filledColor, Color alternate, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, Color border, Color filledColor, Color alternate, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, int border, int filledColor, int alternate, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, int border, int filledColor, int alternate, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
+	
+	//Allows copying the state for easier template creation
+	IProgressStyle copy();
     /// The color that is used for the border of the progress bar
     IProgressStyle borderColor(int c);
+    default IProgressStyle borderColor(Color c) { return borderColor(c.getRGB()); }
 
     /// The color that is used for the background of the progress bar
     IProgressStyle backgroundColor(int c);
+    default IProgressStyle backgroundColor(Color c) { return backgroundColor(c.getRGB()); }
 
     /// The color that is used for the filled part of the progress bar
     IProgressStyle filledColor(int c);
+    default IProgressStyle filledColor(Color c) { return filledColor(c.getRGB()); }
 
     /// If this is different from the filledColor then the fill color will alternate
     IProgressStyle alternateFilledColor(int c);
+    default IProgressStyle alternateFilledColor(Color c) { return alternateFilledColor(c.getRGB()); }
 
     /// If true then text is shown inside the progress bar
     IProgressStyle showText(boolean b);
 
     /// The number format to use for the text inside the progress bar
     IProgressStyle numberFormat(NumberFormat f);
-
-    IProgressStyle prefix(String prefix);
-
-    IProgressStyle suffix(String suffix);
-
-    /// If the progressbar is a lifebar then this is the maximum width
-    IProgressStyle width(int w);
-
-    IProgressStyle height(int h);
-
-    IProgressStyle lifeBar(boolean b);
     
+    IProgressStyle prefix(ITextComponent prefix);
+    IProgressStyle suffix(ITextComponent suffix);
+    
+    default IProgressStyle prefix(String prefix, Object...args) { return prefix(new TranslationTextComponent(prefix, args)); }
+    default IProgressStyle suffix(String suffix, Object...args){ return suffix(new TranslationTextComponent(suffix, args)); }
+    default IProgressStyle prefix(String prefix) { return prefix(new TranslationTextComponent(prefix)); }
+    default IProgressStyle suffix(String suffix){ return suffix(new TranslationTextComponent(suffix)); }
+    
+    /// If the progressbar is a lifebar then this is the maximum width
+    default IProgressStyle bounds(int width, int height) { return width(width).height(height); }
+    IProgressStyle width(int w);
+    IProgressStyle height(int h);
+    IProgressStyle alignment(ElementAlignment align);
+    
+    IProgressStyle lifeBar(boolean b);
     IProgressStyle armorBar(boolean b);
 
     int getBorderColor();
-
     int getBackgroundColor();
-
     int getFilledColor();
-
     int getAlternatefilledColor();
-
+    
+    
     boolean isShowText();
-
     NumberFormat getNumberFormat();
-
+    
     String getPrefix();
-
     String getSuffix();
-
+    ITextComponent getPrefixComp();
+    ITextComponent getSuffixComp();
+    
+    
     int getWidth();
-
     int getHeight();
+    ElementAlignment getAlignment();
 
     boolean isLifeBar();
-
     boolean isArmorBar();
 }

--- a/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
@@ -76,7 +76,6 @@ public interface IProgressStyle {
     int getFilledColor();
     int getAlternatefilledColor();
     
-    
     boolean isShowText();
     NumberFormat getNumberFormat();
     

--- a/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProgressStyle.java
@@ -11,6 +11,7 @@ import net.minecraft.util.text.TranslationTextComponent;
  */
 public interface IProgressStyle {
 	
+	//Default Creation Methods that allow to allow create default instances for most basic cases
 	public static IProgressStyle createDefault() { return new ProgressStyle(); }
 	public static IProgressStyle createArmor() { return new ProgressStyle().armorBar(true); }
 	public static IProgressStyle createLife() { return new ProgressStyle().lifeBar(true); }
@@ -18,23 +19,6 @@ public interface IProgressStyle {
 	public static IProgressStyle createBounds(int width, int height) { return new ProgressStyle().bounds(width, height); }
 	public static IProgressStyle createTextOnly(String prefix) { return new ProgressStyle().prefix(prefix).numberFormat(NumberFormat.NONE); }
 	public static IProgressStyle createText(String prefix, String suffix) { return new ProgressStyle().prefix(prefix).suffix(suffix); }
-	public static IProgressStyle createText(String prefix, String suffix, NumberFormat format) { return new ProgressStyle().showText(true).prefix(prefix).suffix(suffix).numberFormat(format); }
-	public static IProgressStyle createColored(Color border, Color filledColor, Color background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createColored(Color border, Color filledColor, Color alternate, Color background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createColored(int border, int filledColor, int background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createColored(int border, int filledColor, int alternate, int background) { return new ProgressStyle().borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createBorderlessColored(Color filledColor, Color background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createBorderlessColored(Color filledColor, Color alternate, Color background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createBorderlessColored(int filledColor, int background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createBorderlessColored(int filledColor, int alternate, int background) { return new ProgressStyle().backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, Color border, Color filledColor, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, Color border, Color filledColor, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, int border, int filledColor, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, int border, int filledColor, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(filledColor); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, Color border, Color filledColor, Color alternate, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, Color border, Color filledColor, Color alternate, Color background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, int border, int filledColor, int alternate, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
-	public static IProgressStyle createAll(int width, int height, String prefix, String suffix, ElementAlignment align, int border, int filledColor, int alternate, int background) { return new ProgressStyle().bounds(width, height).prefix(prefix).suffix(suffix).alignment(align).borderColor(border).backgroundColor(background).filledColor(filledColor).alternateFilledColor(alternate); }
 	
 	//Allows copying the state for easier template creation
 	IProgressStyle copy();
@@ -53,7 +37,17 @@ public interface IProgressStyle {
     /// If this is different from the filledColor then the fill color will alternate
     IProgressStyle alternateFilledColor(int c);
     default IProgressStyle alternateFilledColor(Color c) { return alternateFilledColor(c.getRGB()); }
-
+    
+    //Helper functions to compress code
+    default IProgressStyle borderlessColor(int filled, int background) { return filledColor(filled).backgroundColor(background); }
+    default IProgressStyle borderlessColor(int filled, int alternate, int background) { return filledColor(filled).alternateFilledColor(alternate).backgroundColor(background); }
+    default IProgressStyle borderlessColor(Color filled, Color background) { return filledColor(filled).backgroundColor(background); }
+    default IProgressStyle borderlessColor(Color filled, Color alternate, Color background) { return filledColor(filled).alternateFilledColor(alternate).backgroundColor(background); }
+    default IProgressStyle color(int border, int filled, int background) { return borderColor(border).filledColor(filled).backgroundColor(background); }
+    default IProgressStyle color(int border, int filled, int alternate, int background) { return borderColor(border).filledColor(filled).alternateFilledColor(alternate).backgroundColor(background); }
+    default IProgressStyle color(Color border, Color filled, Color background) { return borderColor(border).filledColor(filled).backgroundColor(background); }
+    default IProgressStyle color(Color border, Color filled, Color alternate, Color background) { return borderColor(border).filledColor(filled).alternateFilledColor(alternate).backgroundColor(background); }
+    
     /// If true then text is shown inside the progress bar
     IProgressStyle showText(boolean b);
 
@@ -91,11 +85,10 @@ public interface IProgressStyle {
     ITextComponent getPrefixComp();
     ITextComponent getSuffixComp();
     
-    
     int getWidth();
     int getHeight();
     ElementAlignment getAlignment();
-
+    
     boolean isLifeBar();
     boolean isArmorBar();
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
@@ -2,12 +2,16 @@ package mcjty.theoneprobe.apiimpl.client;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import mcjty.theoneprobe.api.IProgressStyle;
 import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import mcjty.theoneprobe.rendering.RenderHelper;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Matrix4f;
+import net.minecraft.util.text.IFormattableTextComponent;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 
 public class ElementProgressRender {
@@ -30,7 +34,7 @@ public class ElementProgressRender {
                         RenderHelper.drawThickBeveledBox(matrixStack, x + 1, y + 1, x + dx + 1, y + h - 1, 1, style.getFilledColor(), style.getFilledColor(), style.getFilledColor());
                     }
                 } else {
-                    for (int xx = x + 1; xx <= x + dx + 1; xx++) {
+                    for (int xx = x + 1; xx < x + dx + 1; xx++) {
                         int color = (xx & 1) == 0 ? style.getFilledColor() : style.getAlternatefilledColor();
                         RenderHelper.drawVerticalLine(matrixStack, xx, y + 1, y + h - 1, color);
                     }
@@ -39,7 +43,22 @@ public class ElementProgressRender {
         }
 
         if (style.isShowText()) {
-            RenderHelper.renderText(Minecraft.getInstance(), matrixStack, x + 3, y + 2, style.getPrefix() + ElementProgress.format(current, style.getNumberFormat(), style.getSuffix()));
+			Minecraft mc = Minecraft.getInstance();
+			FontRenderer render = mc.fontRenderer;
+			ITextComponent s = ((IFormattableTextComponent)style.getPrefixComp()).appendSibling(ElementProgress.format(current, style.getNumberFormat(), style.getSuffixComp()));
+			int textWidth = render.func_243245_a(s.func_241878_f());
+			switch(style.getAlignment())
+			{
+				case ALIGN_BOTTOMRIGHT:
+					RenderHelper.renderText(mc, matrixStack, (x + w - 3) - textWidth, y + 2, s);					
+					break;
+				case ALIGN_CENTER:
+					RenderHelper.renderText(mc, matrixStack, (x + (w / 2)) - (textWidth / 2), y + 2, s);
+					break;
+				case ALIGN_TOPLEFT:
+					RenderHelper.renderText(mc, matrixStack, x + 3, y + 2, s);
+					break;
+			}
         }
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementProgress.java
@@ -47,7 +47,12 @@ public class ElementProgress implements IElement {
                 .armorBar(buf.readBoolean())
                 .alignment(buf.readEnumValue(ElementAlignment.class));
     }
-
+    
+    //Helper method that allows to edit the style of a helper method reducing copy/pasting code from internals
+    public IProgressStyle getStyle() {
+    	return style;
+    }
+    
     private static DecimalFormat dfCommas = new DecimalFormat("###,###");
 
     /**

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -23,6 +23,7 @@ import net.minecraft.tileentity.BrewingStandTileEntity;
 import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 import net.minecraft.world.spawner.AbstractSpawner;
 import net.minecraftforge.energy.CapabilityEnergy;
@@ -215,7 +216,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                             .borderColor(Config.tankbarBorderColor)
                             .numberFormat(Config.tankFormat.get()));
         } else {
-            probeInfo.text(CompoundText.create().style(PROGRESS).text(ElementProgress.format(contents, Config.tankFormat.get(), "mB")));
+            probeInfo.text(CompoundText.create().style(PROGRESS).text(ElementProgress.format(contents, Config.tankFormat.get(), new StringTextComponent("mB"))));
         }
     }
 
@@ -247,7 +248,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                             .borderColor(Config.rfbarBorderColor)
                             .numberFormat(Config.rfFormat.get()));
         } else {
-            probeInfo.text(CompoundText.create().style(PROGRESS).text("FE: " + ElementProgress.format(energy, Config.rfFormat.get(), "FE")));
+            probeInfo.text(CompoundText.create().style(PROGRESS).text("FE: " + ElementProgress.format(energy, Config.rfFormat.get(), new StringTextComponent("FE"))));
         }
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/styles/ProgressStyle.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/styles/ProgressStyle.java
@@ -1,7 +1,11 @@
 package mcjty.theoneprobe.apiimpl.styles;
 
+import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProgressStyle;
 import mcjty.theoneprobe.api.NumberFormat;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 
 /**
  * Style for the progress bar.
@@ -12,15 +16,25 @@ public class ProgressStyle implements IProgressStyle {
     private int filledColor = 0xffaaaaaa;
     private int alternatefilledColor = 0xffaaaaaa;
     private boolean showText = true;
-    private String prefix = "";
-    private String suffix = "";
     private int width = 100;
     private int height = 12;
     private boolean lifeBar = false;
     private boolean armorBar = false;
+	private ElementAlignment alignment = ElementAlignment.ALIGN_TOPLEFT;
+	private ITextComponent prefix = StringTextComponent.EMPTY;
+	private ITextComponent suffix = StringTextComponent.EMPTY;
 
     private NumberFormat numberFormat = NumberFormat.FULL;
-
+    
+    @Override
+    public IProgressStyle copy()
+    {
+    	return new ProgressStyle()
+    			.borderColor(borderColor).backgroundColor(backgroundColor).filledColor(filledColor).alternateFilledColor(alternatefilledColor)
+    			.showText(showText).width(width).height(height).lifeBar(lifeBar).armorBar(armorBar)
+    			.alignment(alignment).prefix(prefix).suffix(suffix).numberFormat(numberFormat);
+    }
+    
     /// The color that is used for the border of the progress bar
     @Override
     public ProgressStyle borderColor(int c) {
@@ -65,17 +79,33 @@ public class ProgressStyle implements IProgressStyle {
 
     @Override
     public ProgressStyle prefix(String prefix) {
-        this.prefix = prefix;
-        return this;
+        return prefix(new TranslationTextComponent(prefix));
     }
 
     @Override
     public ProgressStyle suffix(String suffix) {
-        this.suffix = suffix;
-        return this;
+        return suffix(new TranslationTextComponent(suffix));
     }
-
+    
     @Override
+	public ProgressStyle prefix(ITextComponent prefix) {
+    	this.prefix = prefix;
+		return this;
+	}
+
+	@Override
+	public ProgressStyle suffix(ITextComponent suffix) {
+    	this.suffix = suffix;
+		return this;
+	}
+
+	@Override
+	public ProgressStyle alignment(ElementAlignment align) {
+		this.alignment = align;
+		return this;
+	}
+	
+	@Override
     public ProgressStyle width(int w) {
         this.width = w;
         return this;
@@ -131,14 +161,29 @@ public class ProgressStyle implements IProgressStyle {
 
     @Override
     public String getPrefix() {
-        return prefix;
+        return prefix.getString();
     }
 
     @Override
     public String getSuffix() {
-        return suffix;
+        return suffix.getString();
     }
+    
+	@Override
+	public ITextComponent getPrefixComp() {
+		return prefix;
+	}
 
+	@Override
+	public ITextComponent getSuffixComp() {
+		return suffix;
+	}
+
+	@Override
+	public ElementAlignment getAlignment() {
+		return alignment;
+	}
+    
     @Override
     public int getWidth() {
         return width;

--- a/src/main/java/mcjty/theoneprobe/rendering/RenderHelper.java
+++ b/src/main/java/mcjty/theoneprobe/rendering/RenderHelper.java
@@ -1,7 +1,12 @@
 package mcjty.theoneprobe.rendering;
 
+import javax.annotation.Nullable;
+
+import org.lwjgl.opengl.GL11;
+
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.network.ThrowableIdentity;
 import net.minecraft.client.Minecraft;
@@ -20,10 +25,10 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.vector.Matrix4f;
 import net.minecraft.util.math.vector.Vector3f;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
-import org.lwjgl.opengl.GL11;
-
-import javax.annotation.Nullable;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class RenderHelper {
 
@@ -308,6 +313,37 @@ public class RenderHelper {
 
         return width;
     }
+    
+	@OnlyIn(Dist.CLIENT)
+	public static int renderText(Minecraft mc, MatrixStack stack, int x, int y, ITextComponent text)
+	{
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0f);
+
+        stack.push();
+        stack.translate(0.0F, 0.0F, 32.0F);
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.enableRescaleNormal();
+        RenderSystem.enableLighting();
+        net.minecraft.client.renderer.RenderHelper.setupGui3DDiffuseLighting();
+
+        RenderSystem.disableLighting();
+        RenderSystem.disableDepthTest();
+        RenderSystem.disableBlend();
+        int width = mc.fontRenderer.func_243245_a(text.func_241878_f());//Otherwise it breaks
+        mc.fontRenderer.drawTextWithShadow(stack, text.func_241878_f(), x, y, 16777215);
+        RenderSystem.enableLighting();
+        RenderSystem.enableDepthTest();
+        // Fixes opaque cooldown overlay a bit lower
+        // TODO: check if enabled blending still screws things up down the line.
+        RenderSystem.enableBlend();
+
+
+        stack.pop();
+        RenderSystem.disableRescaleNormal();
+        RenderSystem.disableLighting();
+
+        return width;
+	}
 
     public static class Vector {
         public final float x;


### PR DESCRIPTION
-Optional: Added Default Interface Methods for Creating Progress Style. (can be removed if wanted but shouldn't)
-Suggestion: Styles should be part of the API so defaults or caches can be created
-Fixed: Progressbar was able to overflow (< vs <= in for loop when full).
-Fixed: Progressbars are now Localizable because server can not use language
-Added: Progressbar Text can now be aligned (Yes it has usecases)
-Added: Helper functions for "color" and "bounds" that reduce code but do the same.
-Added: Ability to clone styles

My first suggestion. The wall of text for "Creation of styles" can be removed if really unwanted.
But Styles should be createable even during game load so you can create templates on what you need and add cloning.
Especially if there is a lot of  small replication since instances are shared it reduces memory usage garbage creation and allows to create small changes.

It makes sense with certain design patterns at least. Tell me your thoughts. I can do edits based on what is accepted and not.
Once this is through next patch will be created.

Edit: Tested the patch works with previous versions and just adds a lot of things.
Edit2: Yes the IProgressStyle imports its implementation. But styles should in general be in the API even their impl