### PR TITLE
New Icon Feature that allows much more freedom.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IIconStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IIconStyle.java
@@ -1,9 +1,21 @@
 package mcjty.theoneprobe.api;
 
+import java.awt.Color;
+
+import mcjty.theoneprobe.apiimpl.styles.IconStyle;
+
 /**
  * Style for the icon element.
  */
 public interface IIconStyle {
+	public static IIconStyle createDefault() { return new IconStyle(); }
+	public static IIconStyle createColor(Color color) { return new IconStyle().color(color); }
+	public static IIconStyle createColor(int color) { return new IconStyle().color(color); }
+	public static IIconStyle createBounds(int width, int height) { return new IconStyle().width(width).height(height); }
+	public static IIconStyle createTexBounds(int texWidth, int texHeight) { return new IconStyle().textureWidth(texWidth).textureHeight(texHeight); }
+	
+	
+	IIconStyle copy();
     /**
      * Change the width of the icon. Default is 16
      */
@@ -13,9 +25,9 @@ public interface IIconStyle {
      * Change the height of the icon. Default is 16
      */
     IIconStyle height(int h);
+    default IIconStyle bounds(int w, int h) { return width(w).height(h); }
 
     int getWidth();
-
     int getHeight();
 
     /**
@@ -27,8 +39,13 @@ public interface IIconStyle {
      * Change the total height of the texture on which the icon sits. Default is 256
      */
     IIconStyle textureHeight(int h);
+    default IIconStyle textureBounds(int w, int h) { return textureWidth(w).textureHeight(h); }
 
     int getTextureWidth();
-
     int getTextureHeight();
+    
+    IIconStyle color(int color);
+    default IIconStyle color(Color color) { return color(color.getRGB());}
+    
+    int getColor();
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementIconRender.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementIconRender.java
@@ -6,27 +6,29 @@ import mcjty.theoneprobe.rendering.RenderHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.inventory.container.PlayerContainer;
 import net.minecraft.util.ResourceLocation;
 
 public class ElementIconRender {
 
-    public static void render(ResourceLocation icon, MatrixStack matrixStack, int x, int y, int w, int h, int u, int v, int txtw, int txth) {
-        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+    public static void render(ResourceLocation icon, MatrixStack matrixStack, int x, int y, int w, int h, int u, int v, int txtw, int txth, int color) {
+        RenderSystem.color4f(((color >> 16) & 255) / 255F, ((color >> 8) & 255) / 255F, (color & 255) / 255F, ((color >> 24) & 255) / 255F);
 
         if (icon == null) {
             return;
         }
 
         if (u == -1) {
-            TextureAtlasSprite sprite = Minecraft.getInstance().getAtlasSpriteGetter(AtlasTexture.LOCATION_BLOCKS_TEXTURE).apply(icon);
+            TextureAtlasSprite sprite = Minecraft.getInstance().getAtlasSpriteGetter(PlayerContainer.LOCATION_BLOCKS_TEXTURE).apply(icon);
             if (sprite == null) {
                 return;
             }
-            Minecraft.getInstance().getTextureManager().bindTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE);
+            Minecraft.getInstance().getTextureManager().bindTexture(PlayerContainer.LOCATION_BLOCKS_TEXTURE);
             RenderHelper.drawTexturedModalRect(matrixStack.getLast().getMatrix(), x, y, sprite, w, h);
         } else {
             Minecraft.getInstance().getTextureManager().bindTexture(icon);
             RenderHelper.drawTexturedModalRect(matrixStack.getLast().getMatrix(), x, y, u, v, w, h, txtw, txth);
         }
+        RenderSystem.color4f(1F, 1F, 1F, 1F);
     }
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
@@ -37,12 +37,13 @@ public class ElementIcon implements IElement {
                 .width(buf.readInt())
                 .height(buf.readInt())
                 .textureWidth(buf.readInt())
-                .textureHeight(buf.readInt());
+                .textureHeight(buf.readInt())
+                .color(buf.readInt());
     }
 
     @Override
     public void render(MatrixStack matrixStack, int x, int y) {
-        ElementIconRender.render(icon, matrixStack, x, y, w, h, u, v, style.getTextureWidth(), style.getTextureHeight());
+        ElementIconRender.render(icon, matrixStack, x, y, w, h, u, v, style.getTextureWidth(), style.getTextureHeight(), style.getColor());
     }
 
     @Override
@@ -66,6 +67,7 @@ public class ElementIcon implements IElement {
         buf.writeInt(style.getHeight());
         buf.writeInt(style.getTextureWidth());
         buf.writeInt(style.getTextureHeight());
+        buf.writeInt(style.getColor());
     }
 
     @Override

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementIcon.java
@@ -40,7 +40,11 @@ public class ElementIcon implements IElement {
                 .textureHeight(buf.readInt())
                 .color(buf.readInt());
     }
-
+    
+    public IIconStyle getStyle() {
+    	return style;
+    }
+    
     @Override
     public void render(MatrixStack matrixStack, int x, int y) {
         ElementIconRender.render(icon, matrixStack, x, y, w, h, u, v, style.getTextureWidth(), style.getTextureHeight(), style.getColor());

--- a/src/main/java/mcjty/theoneprobe/apiimpl/styles/IconStyle.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/styles/IconStyle.java
@@ -7,7 +7,13 @@ public class IconStyle implements IIconStyle {
     private int height = 16;
     private int txtw = 256;
     private int txth = 256;
-
+    private int color = -1;
+    
+    @Override
+    public IIconStyle copy() {
+    	return new IconStyle().bounds(width, height).textureBounds(txtw, txth).color(color);
+    }
+    
     @Override
     public IIconStyle width(int w) {
         width = w;
@@ -50,5 +56,16 @@ public class IconStyle implements IIconStyle {
     @Override
     public int getTextureHeight() {
         return txth;
+    }
+    
+    @Override
+    public IIconStyle color(int color) {
+    	this.color = color;
+    	return this;
+    }
+    
+    @Override
+    public int getColor() {
+    	return color;
     }
 }


### PR DESCRIPTION
-Added: IconStyle now has Coloring option (like want to render a fluid with it now you can color it)
-Added: Helper Functions for reducing code (bounds/textureBounds)
-Added: ConstructionHelper functions for IIconStyle
-Added: Clone function to style (needs to be added to others too)
-Added: ElementIcon now supports coloring.
-Fixed: ElementIcon no longer uses deprecated ResourceLocation for block rendering

BlockAtlasTexture is now placed in the PlayerContainer class. No idea why but this is the main reference to be used. Most likely so it can be used server-sided too now.

Color should be in a icon style because if you render a icon you also maybe want to have a color multiplier with it.
Best example: You want to render a fluid with this. Water would be gray and you can only change it with a color multiplier.

I hope this code style also is a bit better.