### PR TITLE
Adding Tanks into One Probe

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
@@ -5,6 +5,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 /**
  * Information to return to the probe. Most methods here return the same probe info
@@ -101,7 +104,21 @@ public interface IProbeInfo {
     IProbeInfo progress(int current, int max);
     IProbeInfo progress(long current, long max, IProgressStyle style);
     IProbeInfo progress(long current, long max);
-
+    
+    
+    /**
+     * This creates a Tank Progress bar of 100 width with Fluid Icon Rendering
+     */
+    default IProbeInfo tankSimple(int capacity, FluidStack fluid) { return tank(TankReference.createSimple(capacity, fluid));}
+    default IProbeInfo tank(IFluidTank tank) { return tank(TankReference.createTank(tank));}
+    default IProbeInfo tankHandler(IFluidHandler handler) { return tank(TankReference.createHandler(handler));}
+    IProbeInfo tank(TankReference tank);
+    
+    default IProbeInfo tankSimple(int capacity, FluidStack fluid, IProgressStyle style) { return tank(TankReference.createSimple(capacity, fluid), style);}
+    default IProbeInfo tank(IFluidTank tank, IProgressStyle style) { return tank(TankReference.createTank(tank), style);}
+    default IProbeInfo tankHandler(IFluidHandler handler, IProgressStyle style) { return tank(TankReference.createHandler(handler), style);}
+    IProbeInfo tank(TankReference tank, IProgressStyle style);
+    
     /**
      * Create a new horizontal probe info as a child of this one. Note that the returned
      * probe info is the new horizontal layout and not this one!

--- a/src/main/java/mcjty/theoneprobe/api/TankReference.java
+++ b/src/main/java/mcjty/theoneprobe/api/TankReference.java
@@ -1,0 +1,51 @@
+package mcjty.theoneprobe.api;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+public final class TankReference {
+	int maxCapacity;
+	int stored;
+	FluidStack[] fluids;
+	
+	public TankReference(int maxCapacity, int stored, FluidStack... fluids) {
+		this.maxCapacity = maxCapacity;
+		this.stored = stored;
+		this.fluids = fluids;
+	}
+	
+	///Simple Self Simulated Tank or just a fluid display
+	public static TankReference createSimple(int maxCapacity, FluidStack fluid) {
+		return new TankReference(maxCapacity, fluid.getAmount(), fluid);
+	}
+	
+	///Simple Tank like FluidTank
+	public static TankReference createTank(IFluidTank tank) {
+		return new TankReference(tank.getCapacity(), tank.getFluidAmount(), tank.getFluid());
+	}
+	
+	///Any Fluid Handler, but Squashes all the fluids into 1 Progress Bar
+	public static TankReference createHandler(IFluidHandler handler) {
+		int maxCapacity = 0;
+		int stored = 0;
+		FluidStack[] fluids = new FluidStack[handler.getTanks()];
+		for(int i = 0;i < fluids.length;i++) {
+			maxCapacity += handler.getTankCapacity(i);
+			FluidStack fluid = handler.getFluidInTank(i);
+			fluids[i] = fluid;
+			stored += fluid.getAmount();
+		}
+		return new TankReference(maxCapacity, stored, fluids);
+	}
+	
+	///Any Fluid Handler but splits each internal Tank into its own Progress Bar
+	public static TankReference[] createSplitHandler(IFluidHandler handler) {
+		TankReference[] references = new TankReference[handler.getTanks()];
+		for(int i = 0;i < references.length;i++) {
+			FluidStack fluid = handler.getFluidInTank(i);
+			references[i] = new TankReference(handler.getTankCapacity(i), fluid.getAmount(), fluid);
+		}
+		return references;
+	}
+}

--- a/src/main/java/mcjty/theoneprobe/apiimpl/TheOneProbeImp.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/TheOneProbeImp.java
@@ -17,6 +17,7 @@ public class TheOneProbeImp implements ITheOneProbe {
     public static int ELEMENT_ENTITY;
     public static int ELEMENT_ICON;
     public static int ELEMENT_ITEMLABEL;
+    public static int ELEMENT_TANK;
 
     private List<IProbeConfigProvider> configProviders = new ArrayList<>();
 
@@ -39,6 +40,7 @@ public class TheOneProbeImp implements ITheOneProbe {
         ELEMENT_ENTITY = TheOneProbe.theOneProbeImp.registerElementFactory(ElementEntity::new);
         ELEMENT_ICON = TheOneProbe.theOneProbeImp.registerElementFactory(ElementIcon::new);
         ELEMENT_ITEMLABEL = TheOneProbe.theOneProbeImp.registerElementFactory(ElementItemLabel::new);
+        ELEMENT_TANK = TheOneProbe.theOneProbeImp.registerElementFactory(ElementTank::new);
     }
 
     private int findProvider(String id) {

--- a/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
@@ -1,18 +1,26 @@
 package mcjty.theoneprobe.apiimpl.client;
 
+import java.util.function.Function;
+
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import mcjty.theoneprobe.api.IProgressStyle;
+import mcjty.theoneprobe.api.TankReference;
 import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import mcjty.theoneprobe.rendering.RenderHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.texture.MissingTextureSprite;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.inventory.container.PlayerContainer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Matrix4f;
 import net.minecraft.util.text.IFormattableTextComponent;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidStack;
 
 public class ElementProgressRender {
 
@@ -41,7 +49,10 @@ public class ElementProgressRender {
                 }
             }
         }
-
+        renderText(matrixStack, x, y, w, current, style);
+    }
+    
+    private static void renderText(MatrixStack matrixStack, int x, int y, int w, long current, IProgressStyle style) {
         if (style.isShowText()) {
 			Minecraft mc = Minecraft.getInstance();
 			FontRenderer render = mc.fontRenderer;
@@ -60,7 +71,7 @@ public class ElementProgressRender {
 			}
         }
     }
-
+    
     private static void renderLifeBar(long current, MatrixStack matrixStack, int x, int y, int w, int h) {
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         Minecraft.getInstance().getTextureManager().bindTexture(ICONS);
@@ -97,5 +108,43 @@ public class ElementProgressRender {
                 RenderHelper.drawTexturedModalRect(matrix, x, y, 25, 9, 9, 9);
             }
         }
+    }
+    
+    public static void renderTank(MatrixStack matrixStack, int x, int y, int width, int height, IProgressStyle style, TankReference tank) {
+		RenderHelper.drawThickBeveledBox(matrixStack, x, y, x + width, y + height, 1, style.getBorderColor(), style.getBorderColor(), style.getBackgroundColor());
+		if(tank.getStored() <= 0) {
+			if(style.isShowText()) {
+				renderText(matrixStack, x, y, width, 0, style);
+			}
+			return;
+		}
+		Minecraft mc = Minecraft.getInstance();
+		mc.getTextureManager().bindTexture(PlayerContainer.LOCATION_BLOCKS_TEXTURE);
+		Function<ResourceLocation, TextureAtlasSprite> map = mc.getAtlasSpriteGetter(PlayerContainer.LOCATION_BLOCKS_TEXTURE);
+		width -= 2;
+		FluidStack[] fluids = tank.getFluids();
+		int start = 1;
+		int tanks = fluids.length;
+		int max = tank.getCapacity();
+		Matrix4f matrix = matrixStack.getLast().getMatrix();
+		for(int i = 0;i<tanks;i++) {
+			FluidStack stack = fluids[i];
+			int lvl = (int)(stack == null ? 0 : (((double)stack.getAmount() / max) * width));
+			if(lvl == 0) continue;
+			FluidAttributes attr = stack.getFluid().getAttributes();
+			TextureAtlasSprite liquidIcon = map.apply(attr.getStillTexture(stack));
+			if(liquidIcon == map.apply(MissingTextureSprite.getLocation())) continue;
+			int color = attr.getColor(stack);
+	        RenderSystem.color4f(((color >> 16) & 255) / 255F, ((color >> 8) & 255) / 255F, (color & 255) / 255F, ((color >> 24) & 255) / 255F);
+			while(lvl != 0)
+			{
+				int maxX = Math.min(16, lvl);
+				lvl -= maxX;
+				RenderHelper.drawTexturedModalRect(matrix, maxX + start, y + 1, liquidIcon, maxX, height - 2);
+				start += maxX;
+			}
+		}
+        RenderSystem.color4f(1F, 1F, 1F, 1F);
+        renderText(matrixStack, x, y, width+2, tank.getStored(), style);
     }
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
@@ -16,6 +16,7 @@ import mcjty.theoneprobe.api.IProbeConfig;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProgressStyle;
 import mcjty.theoneprobe.api.ITextStyle;
+import mcjty.theoneprobe.api.TankReference;
 import mcjty.theoneprobe.apiimpl.ProbeInfo;
 import mcjty.theoneprobe.apiimpl.styles.EntityStyle;
 import mcjty.theoneprobe.apiimpl.styles.IconStyle;
@@ -179,8 +180,20 @@ public abstract class AbstractElementPanel implements IElement, IProbeInfo {
         children.add(new ElementProgress(current, max, style));
         return this;
     }
-
+    
     @Override
+	public IProbeInfo tank(TankReference tank) {
+    	children.add(new ElementTank(tank));
+		return this;
+	}
+    
+	@Override
+	public IProbeInfo tank(TankReference tank, IProgressStyle style) {
+    	children.add(new ElementTank(tank, style));
+		return this;
+	}
+	
+	@Override
     public IProbeInfo horizontal(ILayoutStyle style) {
         ElementHorizontal e = new ElementHorizontal(style.getBorderColor(), style.getSpacing(), style.getAlignment());
         children.add(e);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementTank.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementTank.java
@@ -2,48 +2,86 @@ package mcjty.theoneprobe.apiimpl.elements;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 
+import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IProgressStyle;
+import mcjty.theoneprobe.api.NumberFormat;
 import mcjty.theoneprobe.api.TankReference;
+import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import mcjty.theoneprobe.apiimpl.client.ElementProgressRender;
 import mcjty.theoneprobe.apiimpl.styles.ProgressStyle;
 import net.minecraft.network.PacketBuffer;
 
 public class ElementTank implements IElement {
-	public static int ELEMENT_ID;
-	TankReference reference;
+	TankReference tank;
 	IProgressStyle style;
 	
-	public ElementTank(TankReference reference) {
-		this(reference, new ProgressStyle());
+	public ElementTank(TankReference tank) {
+		this(tank, new ProgressStyle());
 	}
 	
-	public ElementTank(TankReference reference, IProgressStyle style) {
-		this.reference = reference;
+	public ElementTank(TankReference tank, IProgressStyle style) {
+		this.tank = tank;
 		this.style = style;
+	}
+	
+	public ElementTank(PacketBuffer buffer) {
+		tank = new TankReference(buffer);
+        style = new ProgressStyle()
+                .width(buffer.readInt())
+                .height(buffer.readInt())
+                .prefix(buffer.readTextComponent())
+                .suffix(buffer.readTextComponent())
+                .borderColor(buffer.readInt())
+                .filledColor(buffer.readInt())
+                .alternateFilledColor(buffer.readInt())
+                .backgroundColor(buffer.readInt())
+                .showText(buffer.readBoolean())
+                .numberFormat(NumberFormat.values()[buffer.readByte()])
+                .lifeBar(buffer.readBoolean())
+                .armorBar(buffer.readBoolean())
+                .alignment(buffer.readEnumValue(ElementAlignment.class));
+	}
+	
+	public IProgressStyle getStyle() {
+		return style;
 	}
 	
 	@Override
 	public void render(MatrixStack matrixStack, int x, int y) {
-		
+		ElementProgressRender.renderTank(matrixStack, x, y, getWidth(), getHeight(), style, tank);
 	}
 	
 	@Override
 	public int getWidth() {
-		return 0;
+		return style.getWidth();
 	}
 	
 	@Override
 	public int getHeight() {
-		return 0;
+		return style.getHeight();
 	}
 	
 	@Override
 	public void toBytes(PacketBuffer buf) {
-		
+		tank.toBytes(buf);
+        buf.writeInt(style.getWidth());
+        buf.writeInt(style.getHeight());
+        buf.writeTextComponent(style.getPrefixComp());
+        buf.writeTextComponent(style.getSuffixComp());
+        buf.writeInt(style.getBorderColor());
+        buf.writeInt(style.getFilledColor());
+        buf.writeInt(style.getAlternatefilledColor());
+        buf.writeInt(style.getBackgroundColor());
+        buf.writeBoolean(style.isShowText());
+        buf.writeByte(style.getNumberFormat().ordinal());
+        buf.writeBoolean(style.isLifeBar());
+        buf.writeBoolean(style.isArmorBar());
+        buf.writeEnumValue(style.getAlignment());
 	}
 	
 	@Override
 	public int getID() {
-		return 0;
+		return TheOneProbeImp.ELEMENT_TANK;
 	}
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementTank.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementTank.java
@@ -1,0 +1,49 @@
+package mcjty.theoneprobe.apiimpl.elements;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IProgressStyle;
+import mcjty.theoneprobe.api.TankReference;
+import mcjty.theoneprobe.apiimpl.styles.ProgressStyle;
+import net.minecraft.network.PacketBuffer;
+
+public class ElementTank implements IElement {
+	public static int ELEMENT_ID;
+	TankReference reference;
+	IProgressStyle style;
+	
+	public ElementTank(TankReference reference) {
+		this(reference, new ProgressStyle());
+	}
+	
+	public ElementTank(TankReference reference, IProgressStyle style) {
+		this.reference = reference;
+		this.style = style;
+	}
+	
+	@Override
+	public void render(MatrixStack matrixStack, int x, int y) {
+		
+	}
+	
+	@Override
+	public int getWidth() {
+		return 0;
+	}
+	
+	@Override
+	public int getHeight() {
+		return 0;
+	}
+	
+	@Override
+	public void toBytes(PacketBuffer buf) {
+		
+	}
+	
+	@Override
+	public int getID() {
+		return 0;
+	}
+}


### PR DESCRIPTION
Tanks usually are very basic in most mods because its a pain to program into.

So a nice Looking Tank bar that shows you also whats inside of it via the bar is something i propose.

There are 4 types of Tanks supported right out of the gate.
- 1: Simple Fluid (FluidStack, MaxCapacity) nothing fancy but allows to make custom bars without actually implementing IFluidTank
- 2: Simple Tank (IFluidTank) if you have a IFluidTank Instance just drop it in there.
- 3: Merged IFluidHandler (IFluidHandler) Merges all fluids into 1 ProgressBar (Like Tinkers Smeltery)
- 4: Split IFluidHandler (IFluidHandler) Splits all fluids into their Own ProgressBar so you can have a nice easy separation.

That way we can have a unified implementation of Tanks that look nice and all people can just use it right out of the gate.
That might also increase the likely hood that moddevs add support for it on their own.