### PR TITLE
Improvements to panel.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/ILayoutStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/ILayoutStyle.java
@@ -1,12 +1,39 @@
 package mcjty.theoneprobe.api;
 
+import java.awt.Color;
+
+import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
+
 /**
  * Style for a horizonatl or vertical layout.
  */
 public interface ILayoutStyle {
+	
+	public static ILayoutStyle createDefault() { return new LayoutStyle(); }
+	public static ILayoutStyle createBorder(Color color) { return new LayoutStyle().borderColor(color); }
+	public static ILayoutStyle createBorder(Integer color) { return new LayoutStyle().borderColor(color); }
+	public static ILayoutStyle createSpacing(int spacing) { return new LayoutStyle().spacing(spacing); }
+	public static ILayoutStyle createAligned(ElementAlignment align) { return new LayoutStyle().alignment(align); }
+	public static ILayoutStyle createPadding(int padding) { return new LayoutStyle().padding(padding); }
+	public static ILayoutStyle createPadding(int xPadding, int yPadding) { return new LayoutStyle().hPadding(xPadding).vPadding(yPadding); }
+	public static ILayoutStyle createPadding(int top, int bottom, int left, int right) { return new LayoutStyle().topPadding(top).bottomPadding(bottom).leftPadding(left).rightPadding(right); }
+	
+	public ILayoutStyle copy();
+	
+	public default ILayoutStyle padding(int padding) { return topPadding(padding).bottomPadding(padding).leftPadding(padding).rightPadding(padding); }
+	public default ILayoutStyle vPadding(int padding) { return topPadding(padding).bottomPadding(padding); }
+	public default ILayoutStyle hPadding(int padding) { return leftPadding(padding).rightPadding(padding); }
+	
+	/// Padding Methods that allow you to add padding within the border color
+	public ILayoutStyle topPadding(int padding);
+	public ILayoutStyle bottomPadding(int padding);
+	public ILayoutStyle leftPadding(int padding);
+	public ILayoutStyle rightPadding(int padding);
+	
     /// The color that is used for the border of the progress bar
     ILayoutStyle borderColor(Integer c);
-
+    default ILayoutStyle borderColor(Color c) { return borderColor(c == null ? null : Integer.valueOf(c.getRGB())); }
+    
     /**
      * The spacing to use between elements in this panel. -1 means to use default depending
      * on vertical vs horizontal.
@@ -17,7 +44,12 @@ public interface ILayoutStyle {
      * Set the alignment of the elements inside this element. Default is ALIGN_TOPLEFT
      */
     ILayoutStyle alignment(ElementAlignment alignment);
-
+    
+	int getLeftPadding();
+	int getRightPadding();
+	int getTopPadding();
+	int getBottomPadding();
+    
     Integer getBorderColor();
 
     int getSpacing();

--- a/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
@@ -1,5 +1,8 @@
 package mcjty.theoneprobe.api;
 
+import java.util.Collection;
+import java.util.List;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -137,4 +140,32 @@ public interface IProbeInfo {
      * Add a custom element. Make sure the factory for this element is properly registered.
      */
     IProbeInfo element(IElement element);
+    /**
+     * Bulk adding methods for cached elements to be simpler added.
+     * Stuff that never changes
+     */
+    default IProbeInfo elements(IElement...elements) {
+    	for(IElement element : elements) {
+    		element(element);
+    	}
+    	return this;
+    }
+    /**
+     * Bulk adding methods for cached elements to be simpler added.
+     * Stuff that never changes
+     */
+    default IProbeInfo elements(Collection<IElement> elements) {
+    	for(IElement element : elements) {
+    		element(element);
+    	}
+    	return this;
+    }
+    
+    
+    /**
+     * Allows access to the elements stored in the Probe Info via the interface.
+     * Removes the need of Casting to implementation just to achieve what the user wants.
+     * Or for simplifying counting methods if checks happen if a custom Panel has elements or not.
+     */
+    List<IElement> getElements();
 }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/ProbeInfo.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/ProbeInfo.java
@@ -3,6 +3,7 @@ package mcjty.theoneprobe.apiimpl;
 import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.api.*;
 import mcjty.theoneprobe.apiimpl.elements.ElementVertical;
+import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
 import net.minecraft.network.PacketBuffer;
 
 import java.util.ArrayList;
@@ -10,16 +11,12 @@ import java.util.List;
 
 public class ProbeInfo extends ElementVertical {
 
-    public List<IElement> getElements() {
-        return children;
-    }
-
     public void fromBytes(PacketBuffer buf) {
         children = createElements(buf);
     }
 
     public ProbeInfo() {
-        super((Integer) null, 2, ElementAlignment.ALIGN_TOPLEFT);
+    	super(new LayoutStyle().spacing(2).alignment(ElementAlignment.ALIGN_TOPLEFT));
     }
 
     public static List<IElement> createElements(PacketBuffer buf) {

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
@@ -75,6 +75,10 @@ public abstract class AbstractElementPanel implements IElement, IProbeInfo {
 		buf.writeInt(layout.getSpacing()).writeInt(layout.getTopPadding()).writeInt(layout.getBottomPadding()).writeInt(layout.getLeftPadding()).writeInt(layout.getRightPadding());
     }
     
+    public ILayoutStyle getStyle() {
+    	return layout;
+    }
+    
     public List<IElement> getElements() {
         return children;
     }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementHorizontal.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementHorizontal.java
@@ -3,13 +3,19 @@ package mcjty.theoneprobe.apiimpl.elements;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.ILayoutStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import net.minecraft.network.PacketBuffer;
 
 public class ElementHorizontal extends AbstractElementPanel {
 
     public static final int SPACING = 5;
-
+    
+    public ElementHorizontal(ILayoutStyle style) {
+    	super(style);
+	}
+    
+    @Deprecated
     public ElementHorizontal(Integer borderColor, int spacing, ElementAlignment alignment) {
         super(borderColor, spacing, alignment);
     }
@@ -21,15 +27,16 @@ public class ElementHorizontal extends AbstractElementPanel {
     @Override
     public void render(MatrixStack matrixStack, int x, int y) {
         super.render(matrixStack, x, y);
-        if (borderColor != null) {
+        if (layout.getBorderColor() != null) {
             x += 3;
             y += 3;
         }
-        int totHeight = getHeight();
+		x += layout.getLeftPadding();
+		int totHeight = getHeight() - getYPadding();
         for (IElement element : children) {
             int h = element.getHeight();
             int cy = y;
-            switch (alignment) {
+            switch (layout.getAlignment()) {
                 case ALIGN_TOPLEFT:
                     break;
                 case ALIGN_CENTER:
@@ -39,13 +46,13 @@ public class ElementHorizontal extends AbstractElementPanel {
                     cy = y + totHeight - h;
                     break;
             }
-            element.render(matrixStack, x, cy);
-            x += element.getWidth() + spacing;
+            element.render(matrixStack, x, cy + layout.getTopPadding());
+            x += element.getWidth() + layout.getSpacing();
         }
     }
 
     private int getBorderSpacing() {
-        return borderColor == null ? 0 : 6;
+        return layout.getBorderColor() == null ? 0 : 6;
     }
 
     @Override
@@ -54,19 +61,16 @@ public class ElementHorizontal extends AbstractElementPanel {
         for (IElement element : children) {
             w += element.getWidth();
         }
-        return w + spacing * (children.size() - 1) + getBorderSpacing();
+        return w + (layout.getSpacing() * (children.size() - 1)) + getBorderSpacing() + getXPadding();
     }
 
     @Override
     public int getHeight() {
         int h = 0;
         for (IElement element : children) {
-            int hh = element.getHeight();
-            if (hh > h) {
-                h = hh;
-            }
+        	h = Math.max(h, element.getHeight());
         }
-        return h + getBorderSpacing();
+        return h + getBorderSpacing() + getYPadding();
     }
 
     @Override

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementHorizontal.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementHorizontal.java
@@ -5,11 +5,16 @@ import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.ILayoutStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
 import net.minecraft.network.PacketBuffer;
 
 public class ElementHorizontal extends AbstractElementPanel {
 
     public static final int SPACING = 5;
+    
+    public ElementHorizontal(){
+    	super(new LayoutStyle());
+    }
     
     public ElementHorizontal(ILayoutStyle style) {
     	super(style);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementVertical.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementVertical.java
@@ -5,11 +5,16 @@ import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.ILayoutStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
 import net.minecraft.network.PacketBuffer;
 
 public class ElementVertical extends AbstractElementPanel {
 
     public static final int SPACING = 2;
+    
+    public ElementVertical(){
+    	super(new LayoutStyle());
+    }
     
     public ElementVertical(ILayoutStyle style) {
     	super(style);

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementVertical.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementVertical.java
@@ -3,13 +3,19 @@ package mcjty.theoneprobe.apiimpl.elements;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.ILayoutStyle;
 import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
 import net.minecraft.network.PacketBuffer;
 
 public class ElementVertical extends AbstractElementPanel {
 
     public static final int SPACING = 2;
-
+    
+    public ElementVertical(ILayoutStyle style) {
+    	super(style);
+    }
+    
+    @Deprecated
     public ElementVertical(Integer borderColor, int spacing, ElementAlignment alignment) {
         super(borderColor, spacing, alignment);
     }
@@ -21,15 +27,16 @@ public class ElementVertical extends AbstractElementPanel {
     @Override
     public void render(MatrixStack matrixStack, int x, int y) {
         super.render(matrixStack, x, y);
-        if (borderColor != null) {
+        if (layout.getBorderColor() != null) {
             x += 3;
             y += 3;
         }
-        int totWidth = getWidth();
+		y += layout.getTopPadding();
+		int totWidth = getWidth() - getXPadding();
         for (IElement element : children) {
             int w = element.getWidth();
             int cx = x;
-            switch (alignment) {
+            switch (layout.getAlignment()) {
                 case ALIGN_TOPLEFT:
                     break;
                 case ALIGN_CENTER:
@@ -39,13 +46,13 @@ public class ElementVertical extends AbstractElementPanel {
                     cx = x + totWidth - w;
                     break;
             }
-            element.render(matrixStack, cx, y);
-            y += element.getHeight() + spacing;
+            element.render(matrixStack, cx + layout.getLeftPadding(), y);
+            y += element.getHeight() + layout.getSpacing();
         }
     }
-
+    
     private int getBorderSpacing() {
-        return borderColor == null ? 0 : 6;
+        return layout.getBorderColor() == null ? 0 : 6;
     }
 
     @Override
@@ -54,19 +61,16 @@ public class ElementVertical extends AbstractElementPanel {
         for (IElement element : children) {
             h += element.getHeight();
         }
-        return h + spacing * (children.size() - 1) + getBorderSpacing();
+        return h + (layout.getSpacing() * (children.size() - 1)) + getBorderSpacing() + getYPadding();
     }
 
     @Override
     public int getWidth() {
         int w = 0;
         for (IElement element : children) {
-            int ww = element.getWidth();
-            if (ww > w) {
-                w = ww;
-            }
+        	w = Math.max(w, element.getWidth());
         }
-        return w + getBorderSpacing();
+        return w + getBorderSpacing() + getXPadding();
     }
 
     @Override

--- a/src/main/java/mcjty/theoneprobe/apiimpl/styles/LayoutStyle.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/styles/LayoutStyle.java
@@ -10,25 +10,59 @@ public class LayoutStyle implements ILayoutStyle {
     private Integer borderColor = null;
     private ElementAlignment alignment = ElementAlignment.ALIGN_TOPLEFT;
     private int spacing = -1;
-
+    
+    private int top = 0;
+    private int bottom = 0;
+    private int left = 0;
+    private int right = 0;
+    
+    @Override
+    public ILayoutStyle copy() {
+    	return new LayoutStyle().borderColor(borderColor).alignment(alignment).spacing(spacing).bottomPadding(bottom).leftPadding(left).topPadding(top).rightPadding(right);
+    }
+    
     @Override
     public ILayoutStyle alignment(ElementAlignment alignment) {
         this.alignment = alignment;
         return this;
     }
-
+    
     @Override
     public ElementAlignment getAlignment() {
         return alignment;
     }
-
+    
     /// The color that is used for the border of the progress bar
     @Override
     public LayoutStyle borderColor(Integer c) {
         borderColor = c;
         return this;
     }
-
+    
+	@Override
+	public LayoutStyle topPadding(int padding) {
+		top = padding;
+		return this;
+	}
+	
+	@Override
+	public LayoutStyle bottomPadding(int padding) {
+		bottom = padding;
+		return this;
+	}
+	
+	@Override
+	public LayoutStyle leftPadding(int padding) {
+		left = padding;
+		return this;
+	}
+	
+	@Override
+	public LayoutStyle rightPadding(int padding) {
+		right = padding;
+		return this;
+	}
+    
     /**
      * The spacing to use between elements in this panel. -1 means to use default depending
      * on vertical vs horizontal.
@@ -38,14 +72,34 @@ public class LayoutStyle implements ILayoutStyle {
         spacing = f;
         return this;
     }
-
+    
     @Override
     public Integer getBorderColor() {
         return borderColor;
     }
-
+    
     @Override
     public int getSpacing() {
         return spacing;
     }
+    
+	@Override
+	public int getLeftPadding() {
+		return left;
+	}
+	
+	@Override
+	public int getRightPadding() {
+		return right;
+	}
+	
+	@Override
+	public int getTopPadding() {
+		return top;
+	}
+	
+	@Override
+	public int getBottomPadding() {
+		return bottom;
+	}
 }


### PR DESCRIPTION
-Added: Padding to the inner of the panel (Border does not change)
-Added: Style is used in the panel. Original constructors exist but depricated for a reason.
-Added: Access to elements for easier control of one probe data no api access required.
-Added: Bulk Adding of Elements for caches.
-Added: LayoutStyle copy method and padding methods.
-Added: Default Constructing methods for ILayoutStyle

Panel improvements for you.

Padding was added into panels because it was really nesseary. You couldn't just move elements that easy or had to cascade elements with spacing just to get enough padding out.

Also Panels use now layout styles by default because why are they the only ones that don't do it?
getElement access because you were only able to see injected elements into the root node. But if you created your own you had to imeplement 2 for loops for elements that were only optional if they were filled. So this fixes the need for that because you can actually read your own builded elements.

Also to just give a ETA on how much is left.
Eh after this maybe 2-3 patches? 1 New component that is really small.
1 patch for the other styles so they are uniform with the new system.
And maybe a third for things i find on the way. But I will tell you if i am done with the last patch.

(I will prepare the other 2 patches right after)