### PR TITLE
1.16 fixes

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IEntityStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IEntityStyle.java
@@ -1,9 +1,17 @@
 package mcjty.theoneprobe.api;
 
+import mcjty.theoneprobe.apiimpl.styles.EntityStyle;
+
 /**
  * Style for the entity element.
  */
 public interface IEntityStyle {
+	public static IEntityStyle createDefault() { return new EntityStyle(); }
+	public static IEntityStyle createBounds(int width, int height) { return new EntityStyle().bounds(width, height); }
+	public static IEntityStyle createScale(float scale) { return new EntityStyle().scale(scale); }
+	
+	IEntityStyle copy();
+	
     /**
      * Change the width of the element. Default is 25
      */
@@ -13,6 +21,7 @@ public interface IEntityStyle {
      * Change the height of the element. Default is 25
      */
     IEntityStyle height(int h);
+    default IEntityStyle bounds(int width, int height) { return width(width).height(height); }
 
     /**
      * Change the scale of the entity inside the element. Default is 1.0 which

--- a/src/main/java/mcjty/theoneprobe/api/IItemStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IItemStyle.java
@@ -1,14 +1,20 @@
 package mcjty.theoneprobe.api;
 
+import mcjty.theoneprobe.apiimpl.styles.ItemStyle;
+
 /**
  * Style for the item element.
  */
 public interface IItemStyle {
-    IItemStyle width(int w);
-
+	public static IItemStyle createDefault() { return new ItemStyle();}
+	public static IItemStyle createBounds(int width, int height) { return new ItemStyle().bounds(width, height);}
+	
+	IItemStyle copy();
+	
+	IItemStyle width(int w);
     IItemStyle height(int h);
-
+    default IItemStyle bounds(int width, int height) { return width(width).height(height); }
+    
     int getWidth();
-
     int getHeight();
 }

--- a/src/main/java/mcjty/theoneprobe/api/IOverlayStyle.java
+++ b/src/main/java/mcjty/theoneprobe/api/IOverlayStyle.java
@@ -1,10 +1,14 @@
 package mcjty.theoneprobe.api;
 
+import java.awt.Color;
+
 /**
  * The style for the overlay.
  */
 public interface IOverlayStyle {
-
+	
+	
+	IOverlayStyle copy();
     /**
      * The offset of the border around the box. Use 0 to disable.
      */
@@ -25,6 +29,7 @@ public interface IOverlayStyle {
      * 0xFFFFFFFF is pure white, 0x22FF0000 is a very faint transparent red.
      */
     IOverlayStyle borderColor(int color);
+    default IOverlayStyle borderColor(Color color) { return borderColor(color.getRGB()); }
 
     int getBorderColor();
 
@@ -32,9 +37,10 @@ public interface IOverlayStyle {
      * The color of the box.
      */
     IOverlayStyle boxColor(int color);
-
+    default IOverlayStyle boxColor(Color color) { return boxColor(color.getRGB()); }
+    
     int getBoxColor();
-
+    
     /**
      * The location of the overlay box.
      * You can use -1 to indicate some location is not to be used. If
@@ -46,7 +52,7 @@ public interface IOverlayStyle {
      * be the X coordinate of the right side of the overlay box.
      */
     IOverlayStyle location(int leftX, int rightX, int topY, int bottomY);
-
+    
     int getLeftX();
 
     int getRightX();

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -312,22 +312,23 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
             block = ((SilverfishBlock) block).getMimickedBlock();
             pickBlock = new ItemStack(block, 1);
         }
-
+        
         if (block instanceof FlowingFluidBlock) {
-            FluidState fluidState = block.getFluidState(blockState);
+            FluidState fluidState = blockState.getFluidState();
             Fluid fluid = fluidState.getFluid();
             if (fluid != Fluids.EMPTY) {
-                FluidStack fluidStack = new FluidStack(fluid.getFluid(), BUCKET_VOLUME);
-                ItemStack bucketStack = FluidUtil.getFilledBucket(fluidStack);
-
                 IProbeInfo horizontal = probeInfo.horizontal();
-                FluidUtil.getFluidContained(bucketStack).ifPresent(fc -> {
-                    if (fluidStack.isFluidEqual(fc)) {
-                        horizontal.item(bucketStack);
-                    } else {
-                        horizontal.icon(fluid.getAttributes().getStillTexture(), -1, -1, 16, 16, probeInfo.defaultIconStyle().width(20));
-                    }
-                });
+                FluidStack fluidStack = new FluidStack(fluid.getFluid(), BUCKET_VOLUME);
+                horizontal.icon(fluid.getAttributes().getStillTexture(), -1, -1, 16, 16, probeInfo.defaultIconStyle().width(20).color(fluid.getAttributes().getColor(fluidStack)));
+                //Proposal Fluids should look at the icon only not buckets of it. Dunno you have to decide. I just fixed the fluid color bug
+//              ItemStack bucketStack = FluidUtil.getFilledBucket(fluidStack);
+//                FluidUtil.getFluidContained(bucketStack).ifPresent(fc -> {
+//                    if (fluidStack.isFluidEqual(fc)) {
+//                        horizontal.item(bucketStack);
+//                    } else {
+//                        horizontal.icon(fluid.getAttributes().getStillTexture(), -1, -1, 16, 16, probeInfo.defaultIconStyle().width(20).color(fluid.getAttributes().getColor(fluidStack)));
+//                    }
+//                });
 
                 horizontal.vertical()
                         .text(CompoundText.create().name(fluidStack.getTranslationKey()))
@@ -351,7 +352,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
         } else {
             if (Tools.show(mode, config.getShowModName())) {
                 probeInfo.vertical()
-                        .text(CompoundText.create().name(block.getTranslationKey()))
+                        .text(CompoundText.create().name(block.getTranslationKey()))//This should maybe send over the registry name and convert it into the block name on the client
                         .text(CompoundText.create().style(MODNAME).text(modName));
             } else {
                 probeInfo.vertical()

--- a/src/main/java/mcjty/theoneprobe/apiimpl/styles/EntityStyle.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/styles/EntityStyle.java
@@ -6,7 +6,12 @@ public class EntityStyle implements IEntityStyle {
     private int width = 25;
     private int height = 25;
     private float scale = 1.0f;
-
+    
+    @Override
+    public IEntityStyle copy() {
+    	return new EntityStyle().bounds(width, height).scale(scale);
+    }
+    
     @Override
     public IEntityStyle width(int w) {
         this.width = w;

--- a/src/main/java/mcjty/theoneprobe/apiimpl/styles/ItemStyle.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/styles/ItemStyle.java
@@ -5,7 +5,11 @@ import mcjty.theoneprobe.api.IItemStyle;
 public class ItemStyle implements IItemStyle {
     private int width = 20;
     private int height = 20;
-
+    
+    public IItemStyle copy() {
+    	return new ItemStyle().bounds(width, height);
+    }
+    
     @Override
     public IItemStyle width(int w) {
         width = w;


### PR DESCRIPTION
Small fixes & Proposal.

-Fixed: Fluids now support color with their icon. (Water would have been gray if the bucket wasn't there)
-Added: Fluids are displayed as Panel instead of a Item. (Can be removed if unwanted)

Also there is a couple other things that should be done but i am opening issues for these. But if you want to make a todolist yourself.

Your CompoundText should allow for "registry names" that you don't have to use getTranslationKey() because there are cases where getDisplayName is overriden because the text component is not a single string but a compound string. (TranslationComponents but with a lot of sibilibgs)

Also your mod should be localized now that it is possible to do so. (I mean all the strings oneprobe has on its own)

But this would be my last patch.