### PR TITLE
Tank Fixes & Implementation into one probe.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/client/ElementProgressRender.java
@@ -139,7 +139,7 @@ public class ElementProgressRender {
             while (lvl != 0) {
                 int maxX = Math.min(16, lvl);
                 lvl -= maxX;
-                RenderHelper.drawTexturedModalRect(matrix, maxX + start, y + 1, liquidIcon, maxX, height - 2);
+                RenderHelper.drawTexturedModalRect(matrix, x + start, y + 1, liquidIcon, maxX, height - 2);
                 start += maxX;
             }
         }

--- a/src/main/java/mcjty/theoneprobe/config/Config.java
+++ b/src/main/java/mcjty/theoneprobe/config/Config.java
@@ -194,8 +194,8 @@ public class Config {
                 .comment("How to display RF: 0 = do not show, 1 = show in a bar, 2 = show as text")
                 .defineInRange("showRF", DEFAULT_CONFIG.getRFMode(), 0, 2);
         defaultTankMode = COMMON_BUILDER
-                .comment("How to display tank contents: 0 = do not show, 1 = show in a bar, 2 = show as text")
-                .defineInRange("showTank", DEFAULT_CONFIG.getRFMode(), 0, 2);
+                .comment("How to display tank contents: 0 = do not show, 1 = show in fluid bar, 2 = show in a bar, 3 = show as text")
+                .defineInRange("showTank", DEFAULT_CONFIG.getRFMode(), 0, 3);
         rfFormat = addEnumConfig(COMMON_BUILDER, "rfFormat", "Format for displaying RF",
                 NumberFormat.COMPACT, NumberFormat.COMMAS, NumberFormat.COMPACT, NumberFormat.FULL, NumberFormat.NONE);
         tankFormat = addEnumConfig(COMMON_BUILDER, "tankFormat", "Format for displaying tank contents",


### PR DESCRIPTION
-Added: One Probe now can use fancy tanks if wanted.
-Fixed: Tank Renderer was bugged out from the conversion from internal override to offical release.
-Added: Config to select which tank bar should be used.
-Added: Fluid Tank by default uses color from fluid (for background and normal color)

