### PR TITLE
More API improvements.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
@@ -60,6 +60,24 @@ public interface IProbeInfo {
      * Create a default style for the icon element
      */
     IIconStyle defaultIconStyle();
+    
+    /**
+     * Creates a Vertical Panel without adding it to elements.
+     */
+    IProbeInfo createVerticalPanel();
+    IProbeInfo createVerticalPanel(ILayoutStyle style);
+    
+    /**
+     * Creates a Horizontal Panel without adding it to elements.
+     */
+    IProbeInfo createHorizontalPanel();
+    IProbeInfo createHorizontalPanel(ILayoutStyle style);
+    
+    /**
+     * Converts the ProbeInfo into the element. Reduces casting.
+     */
+    IElement asElement();
+    
 
     /**
      * Create an icon. If u and v are -1 then the default texture atlas is used

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
@@ -290,4 +290,29 @@ public abstract class AbstractElementPanel implements IElement, IProbeInfo {
     public IIconStyle defaultIconStyle() {
         return new IconStyle();
     }
+    
+	@Override
+	public IProbeInfo createVerticalPanel() {
+		return new ElementVertical(new LayoutStyle().spacing(ElementVertical.SPACING).alignment(ElementAlignment.ALIGN_TOPLEFT));
+	}
+
+	@Override
+	public IProbeInfo createVerticalPanel(ILayoutStyle style) {
+		return new ElementVertical(style);
+	}
+
+	@Override
+	public IProbeInfo createHorizontalPanel() {
+		return new ElementHorizontal(new LayoutStyle().spacing(layout.getSpacing()).alignment(ElementAlignment.ALIGN_TOPLEFT));
+	}
+
+	@Override
+	public IProbeInfo createHorizontalPanel(ILayoutStyle style) {
+		return new ElementHorizontal(style);
+	}
+	
+	@Override
+	public IElement asElement() {
+		return this;
+	}
 }


### PR DESCRIPTION
-Added: A way to create a Panel without adding it into the probe.
-Added: Turning a ProbeInfo into a Element so you can actually add it without a unsave cast.

Reason i add this:
If you want to fully control how elements are added you have to use the API implementation there is no way to add a element without 5 extra steps to just create a panel without adding it to the current info.

Also this new feature requires that IProbeInfos are convertable to IElement so you can actually add them.

This provides a lot more control.

Note: This could break custom implementations if they didn't implement the new API methods.
Another note: This technically could be moved into the "Style" Creator API if wanted. But this would not work idealy with dynamic data. Though maybe i am adding that later to it.