### PR TITLE
Disable entity shadow rendering in gui for optimization and compatibility.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/rendering/RenderHelper.java
+++ b/src/main/java/mcjty/theoneprobe/rendering/RenderHelper.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
@@ -62,13 +63,16 @@ public class RenderHelper {
 
         matrixStack.translate(0.0F, (float) entity.getMyRidingOffset() + (entity instanceof HangingEntity ? 0.5F : 0.0F), 0.0F);
 
+        EntityRendererManager dispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
         try {
             IRenderTypeBuffer.Impl buffer = Minecraft.getInstance().renderBuffers().bufferSource();
-            Minecraft.getInstance().getEntityRenderDispatcher().render(entity, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F, matrixStack, buffer, 15728880);
+            dispatcher.setRenderShadow(false);
+            dispatcher.render(entity, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F, matrixStack, buffer, 15728880);
             buffer.endBatch();
         } catch (Exception e) {
             TheOneProbe.logger.error("Error rendering entity!", e);
         }
+        dispatcher.setRenderShadow(true);
         net.minecraft.client.renderer.RenderHelper.turnOff();
 
         RenderSystem.disableRescaleNormal();


### PR DESCRIPTION
There is one flag in `EntityRendererManager` that makes entity shadows not render. Used in player's `InventoryScreen`. It's called `setRenderShadow` and does not have any getters. But this is the most reliable way to check if an entity is rendered in any sort of GUI, so me and potentially some other mod devs are forced to access transform this field in order to check if entity is rendered in GUI.

The problem is that TOP doesn't update this field on entity render.

Also, even though entity shadow is not visible in TOP overlay (because it is perpendicular to the camera due to orthographic projection) this change will disable shadows for any rendered entity and save some rendering time for players, potentially without any visual differences.