### PR TITLE
Show chest contents for boats and minecarts

### DIFF
--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/ChestInfoTools.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/ChestInfoTools.java
@@ -6,12 +6,15 @@ import mcjty.theoneprobe.apiimpl.styles.ItemStyle;
 import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
 import mcjty.theoneprobe.config.Config;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -25,20 +28,31 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ChestInfoTools {
 
     static void showChestInfo(ProbeMode mode, IProbeInfo probeInfo, Level world, BlockPos pos, IProbeConfig config) {
+        ResourceLocation registryKey = ForgeRegistries.BLOCKS.getKey(world.getBlockState(pos).getBlock());
+        BlockEntity te = world.getBlockEntity(pos);
+        showChestInfo(mode, probeInfo, registryKey, te, config);
+    }
+
+    static void showChestInfo(ProbeMode mode, IProbeInfo probeInfo, Entity entity, IProbeConfig config) {
+        ResourceLocation registryKey = ForgeRegistries.ENTITY_TYPES.getKey(entity.getType());
+        showChestInfo(mode, probeInfo, registryKey, entity, config);
+    }
+
+    private static void showChestInfo(ProbeMode mode, IProbeInfo probeInfo, ResourceLocation registryKey, ICapabilityProvider entity, IProbeConfig config) {
         List<ItemStack> stacks = null;
         IProbeConfig.ConfigMode chestMode = config.getShowChestContents();
         if (chestMode == IProbeConfig.ConfigMode.EXTENDED && (Config.showSmallChestContentsWithoutSneaking.get() > 0 || !Config.getInventoriesToShow().isEmpty())) {
-            if (Config.getInventoriesToShow().contains(ForgeRegistries.BLOCKS.getKey(world.getBlockState(pos).getBlock()))) {
+            if (Config.getInventoriesToShow().contains(registryKey)) {
                 chestMode = IProbeConfig.ConfigMode.NORMAL;
             } else if (Config.showSmallChestContentsWithoutSneaking.get() > 0) {
                 stacks = new ArrayList<>();
-                int slots = getChestContents(world, pos, stacks);
+                int slots = getChestContents(entity, registryKey, stacks);
                 if (slots <= Config.showSmallChestContentsWithoutSneaking.get()) {
                     chestMode = IProbeConfig.ConfigMode.NORMAL;
                 }
             }
         } else if (chestMode == IProbeConfig.ConfigMode.NORMAL && !Config.getInventoriesToNotShow().isEmpty()) {
-            if (Config.getInventoriesToNotShow().contains(ForgeRegistries.BLOCKS.getKey(world.getBlockState(pos).getBlock()))) {
+            if (Config.getInventoriesToNotShow().contains(registryKey)) {
                 chestMode = IProbeConfig.ConfigMode.EXTENDED;
             }
         }
@@ -46,12 +60,12 @@ public class ChestInfoTools {
         if (Tools.show(mode, chestMode)) {
             if (stacks == null) {
                 stacks = new ArrayList<>();
-                getChestContents(world, pos, stacks);
+                getChestContents(entity, registryKey, stacks);
             }
 
             if (!stacks.isEmpty()) {
                 boolean showDetailed = Tools.show(mode, config.getShowChestContentsDetailed()) && stacks.size() <= Config.showItemDetailThresshold.get();
-                showChestContents(probeInfo, world, pos, stacks, showDetailed);
+                showChestContents(probeInfo, stacks, showDetailed);
             }
         }
     }
@@ -75,7 +89,7 @@ public class ChestInfoTools {
         }
     }
 
-    private static void showChestContents(IProbeInfo probeInfo, Level world, BlockPos pos, List<ItemStack> stacks, boolean detailed) {
+    private static void showChestContents(IProbeInfo probeInfo, List<ItemStack> stacks, boolean detailed) {
         int rows = 0;
         int idx = 0;
 
@@ -103,28 +117,26 @@ public class ChestInfoTools {
         }
     }
 
-    private static int getChestContents(Level world, BlockPos pos, List<ItemStack> stacks) {
-        BlockEntity te = world.getBlockEntity(pos);
-
+    private static int getChestContents(ICapabilityProvider inventory, ResourceLocation registryKey, List<ItemStack> stacks) {
         Set<Item> foundItems = Config.compactEqualStacks.get() ? new HashSet<>() : null;
         AtomicInteger maxSlots = new AtomicInteger();
         try {
-            if (te != null && te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).isPresent()) {
-                te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(capability -> {
+            if (inventory != null && inventory.getCapability(ForgeCapabilities.ITEM_HANDLER).isPresent()) {
+                inventory.getCapability(ForgeCapabilities.ITEM_HANDLER).ifPresent(capability -> {
                     maxSlots.set(capability.getSlots());
                     for (int i = 0; i < maxSlots.get(); i++) {
                         addItemStack(stacks, foundItems, capability.getStackInSlot(i));
                     }
 
                 });
-            } else if (te instanceof Container inventory) {
-                maxSlots.set(inventory.getContainerSize());
+            } else if (inventory instanceof Container container) {
+                maxSlots.set(container.getContainerSize());
                 for (int i = 0; i < maxSlots.get(); i++) {
-                    addItemStack(stacks, foundItems, inventory.getItem(i));
+                    addItemStack(stacks, foundItems, container.getItem(i));
                 }
             }
         } catch (RuntimeException e) {
-            throw new RuntimeException("Getting the contents of a " + ForgeRegistries.BLOCKS.getKey(world.getBlockState(pos).getBlock()) + " (" + te.getClass().getName() + ")", e);
+            throw new RuntimeException("Getting the contents of a " + registryKey + " (" + inventory.getClass().getName() + ")", e);
         }
         return maxSlots.get();
     }

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoEntityProvider.java
@@ -19,6 +19,7 @@ import net.minecraft.world.entity.animal.Wolf;
 import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.vehicle.ContainerEntity;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -155,6 +156,10 @@ public class DefaultProbeInfoEntityProvider implements IProbeInfoEntityProvider 
                 DyeColor collarColor = wolf.getCollarColor();
                 probeInfo.text(CompoundText.createLabelInfo("Collar: ", collarColor.getSerializedName()));
             }
+        }
+
+        if (entity instanceof ContainerEntity) {
+            ChestInfoTools.showChestInfo(mode, probeInfo, entity, config);
         }
     }
 

--- a/src/main/java/mcjty/theoneprobe/config/Config.java
+++ b/src/main/java/mcjty/theoneprobe/config/Config.java
@@ -255,11 +255,11 @@ public class Config {
                 .comment("The maximum amount of slots (empty or not) to show without sneaking")
                 .defineInRange("showSmallChestContentsWithoutSneaking", 0, 0, 1000);
         showContentsWithoutSneaking = COMMON_BUILDER
-                .comment("A list of blocks for which we automatically show chest contents even if not sneaking")
+                .comment("A list of blocks and entities for which we automatically show contents even if not sneaking")
                 .defineList("showContentsWithoutSneaking", new ArrayList<>(Arrays.asList("storagedrawers:basicdrawers", "storagedrawersextra:extra_drawers")),
                         s -> s instanceof String);
         dontShowContentsUnlessSneaking = COMMON_BUILDER
-                .comment("A list of blocks for which we don't show chest contents automatically except if sneaking")
+                .comment("A list of blocks and entities for which we don't show contents automatically except if sneaking")
                 .defineList("dontShowContentsUnlessSneaking", new ArrayList<>(),
                         s -> s instanceof String);
 


### PR DESCRIPTION
Adds the chest info to `net.minecraft.world.entity.vehicle.ContainerEntity` entities:

* Boat with Chest
  ![image](https://user-images.githubusercontent.com/1509051/221992320-5b015a65-ee42-4475-b6ba-4dd6ad431423.png)
* Minecart with Chest
  ![image](https://user-images.githubusercontent.com/1509051/221992279-0438e64c-94d5-4a82-a929-8bc26709dc44.png)
* Minecart with Hopper
  ![image](https://user-images.githubusercontent.com/1509051/221992368-fb076816-d34b-4af7-8887-fe37df340aac.png)

Was able to do some abstraction without duplicating most of the existing code, as both `BlockEntity` and `ContainerEntity` are `ICapabilityProvider` and `Container`.

Also updated the comments of 'showContentsWithoutSneaking' and 'dontShowContentsUnlessSneaking' config settings to reflect that these vehicle entities can be added as well.
